### PR TITLE
Predix/flyway scope length fix 4.4.0

### DIFF
--- a/server/src/main/resources/org/cloudfoundry/identity/uaa/db/hsqldb/V2_5_5__ExtendClientAuthScopeSize.sql
+++ b/server/src/main/resources/org/cloudfoundry/identity/uaa/db/hsqldb/V2_5_5__ExtendClientAuthScopeSize.sql
@@ -1,0 +1,2 @@
+ALTER TABLE oauth_client_details ALTER COLUMN scope CLOB;
+ALTER TABLE oauth_client_details ALTER COLUMN authorities CLOB;

--- a/server/src/main/resources/org/cloudfoundry/identity/uaa/db/hsqldb/V4_0_9__ExtendClientAuthScopeSize.sql
+++ b/server/src/main/resources/org/cloudfoundry/identity/uaa/db/hsqldb/V4_0_9__ExtendClientAuthScopeSize.sql
@@ -1,3 +1,0 @@
-ALTER TABLE oauth_client_details ALTER COLUMN scope VARCHAR(4000);
-ALTER TABLE oauth_client_details ALTER COLUMN authorities VARCHAR(4000);
-ALTER TABLE revocable_tokens ALTER COLUMN scope VARCHAR(4000);

--- a/server/src/main/resources/org/cloudfoundry/identity/uaa/db/mysql/V2_5_5__ExtendClientAuthScopeSize.sql
+++ b/server/src/main/resources/org/cloudfoundry/identity/uaa/db/mysql/V2_5_5__ExtendClientAuthScopeSize.sql
@@ -1,0 +1,2 @@
+ALTER TABLE oauth_client_details MODIFY scope TEXT;
+ALTER TABLE oauth_client_details MODIFY authorities TEXT;

--- a/server/src/main/resources/org/cloudfoundry/identity/uaa/db/mysql/V4_0_9__ExtendClientAuthScopeSize.sql
+++ b/server/src/main/resources/org/cloudfoundry/identity/uaa/db/mysql/V4_0_9__ExtendClientAuthScopeSize.sql
@@ -1,3 +1,0 @@
-ALTER TABLE oauth_client_details MODIFY scope VARCHAR(4000);
-ALTER TABLE oauth_client_details MODIFY authorities VARCHAR(4000);
-ALTER TABLE revocable_tokens MODIFY scope VARCHAR(4000);

--- a/server/src/main/resources/org/cloudfoundry/identity/uaa/db/postgresql/V2_5_5__ExtendClientAuthScopeSize.sql
+++ b/server/src/main/resources/org/cloudfoundry/identity/uaa/db/postgresql/V2_5_5__ExtendClientAuthScopeSize.sql
@@ -1,0 +1,3 @@
+ALTER TABLE oauth_client_details ALTER COLUMN scope TYPE TEXT;
+ALTER TABLE oauth_client_details ALTER COLUMN authorities TYPE TEXT;
+

--- a/server/src/main/resources/org/cloudfoundry/identity/uaa/db/postgresql/V4_0_9__ExtendClientAuthScopeSize.sql
+++ b/server/src/main/resources/org/cloudfoundry/identity/uaa/db/postgresql/V4_0_9__ExtendClientAuthScopeSize.sql
@@ -1,3 +1,0 @@
-ALTER TABLE oauth_client_details ALTER COLUMN scope TYPE VARCHAR(4000);
-ALTER TABLE oauth_client_details ALTER COLUMN authorities TYPE VARCHAR(4000);
-ALTER TABLE revocable_tokens ALTER COLUMN scope TYPE VARCHAR(4000);

--- a/server/src/main/resources/org/cloudfoundry/identity/uaa/db/sqlserver/V4_0_9__ExtendClientAuthScopeSize.sql
+++ b/server/src/main/resources/org/cloudfoundry/identity/uaa/db/sqlserver/V4_0_9__ExtendClientAuthScopeSize.sql
@@ -1,5 +1,0 @@
-ALTER TABLE oauth_client_details ALTER COLUMN scope NVARCHAR(4000);
-ALTER TABLE oauth_client_details ALTER COLUMN authorities NVARCHAR(4000);
-ALTER TABLE revocable_tokens ALTER COLUMN scope NVARCHAR(4000);
-
-


### PR DESCRIPTION
1. Revert the restriction to 4000
2. Bring back the script that did type change to `TEXT` for flyway script consistency purposes, let's say we deploy `uaa` in a new environment.