### PR TITLE
Create account should not have default value

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
@@ -752,7 +752,7 @@ public class LoginInfoEndpoint {
 
         boolean selfServiceLinksEnabled = (zone.getConfig()!=null) ? zone.getConfig().getLinks().getSelfService().isSelfServiceLinksEnabled() : true;
 
-        final String defaultSignup = "/create_account";
+        final String defaultSignup = "";
         final String defaultPasswd = "/forgot_password";
         Links.SelfService service = zone.getConfig()!=null ? zone.getConfig().getLinks().getSelfService() : null;
         String signup = UaaStringUtils.nonNull(

--- a/server/src/main/resources/templates/web/login.html
+++ b/server/src/main/resources/templates/web/login.html
@@ -38,10 +38,10 @@
                 </div>
             </div>
         </div>
-        <div class="island-footer">
+        <div class="island-footer" th:style="${#strings.isEmpty(links['createAccountLink'])?'display:inline-block':''}">
           <th:block th:if="${linkCreateAccountShow} and not ${disableInternalUserManagement}">
-          <span class="left">
-              <a th:unless="${#strings.isEmpty(links['createAccountLink'])}" href="/create_account" th:href="@{${links['createAccountLink']}}" class="link-lowlight">Create account</a>
+          <span th:unless="${#strings.isEmpty(links['createAccountLink'])}" class="left">
+              <a href="/create_account" th:href="@{${links['createAccountLink']}}" class="link-lowlight">Create account</a>
           </span>
           <span class="right" th:unless="${#strings.isEmpty(links['forgotPasswordLink'])}">
               <a href="/forgot_password" th:href="@{${links['forgotPasswordLink']}}" class="link-lowlight">Reset password</a>

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpointTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpointTests.java
@@ -326,6 +326,39 @@ public class LoginInfoEndpointTests {
         validateSelfServiceLinks("/local_signup?domain="+zone.getSubdomain(), "/local_passwd?id="+zone.getId(), endpoint.getSelfServiceLinks());
     }
 
+    @Test
+    public void testSelfServiceLinksDoNotHaveDefaultValues() {
+        LoginInfoEndpoint endpoint = getEndpoint();
+        IdentityZone zone = new IdentityZone();
+        zone.setName("some_other_zone");
+        zone.setId("some_id");
+        zone.setSubdomain(zone.getName());
+        IdentityZoneConfiguration config = zone.getConfig();
+        IdentityZoneHolder.set(zone);
+
+        IdentityZoneHolder.get().getConfig().getLinks().getSelfService().setSignup(null);
+        IdentityZoneHolder.get().getConfig().getLinks().getSelfService().setPasswd("http://custom_passwd_link");
+        endpoint.loginForHtml(model, null, new MockHttpServletRequest());
+        validateSelfServiceLinks(null, "http://custom_passwd_link", model);
+        validateSelfServiceLinks(null, "http://custom_passwd_link", endpoint.getSelfServiceLinks());
+
+        IdentityZoneHolder.get().getConfig().getLinks().getSelfService().setSignup("");
+        IdentityZoneHolder.get().getConfig().getLinks().getSelfService().setPasswd("http://custom_passwd_link");
+        endpoint.loginForHtml(model, null, new MockHttpServletRequest());
+        validateSelfServiceLinks(null, "http://custom_passwd_link", model);
+        validateSelfServiceLinks(null, "http://custom_passwd_link", endpoint.getSelfServiceLinks());
+
+        IdentityZoneHolder.get().getConfig().getLinks().getSelfService().setSignup("http://custom_signup_link");
+        IdentityZoneHolder.get().getConfig().getLinks().getSelfService().setPasswd("");
+        endpoint.loginForHtml(model, null, new MockHttpServletRequest());
+        validateSelfServiceLinks("http://custom_signup_link", null, model);
+        validateSelfServiceLinks("http://custom_signup_link", null, endpoint.getSelfServiceLinks());
+
+        //null config
+        zone.setConfig(null);
+        validateSelfServiceLinks(null, "/forgot_password", endpoint.getSelfServiceLinks());
+    }
+
     public void validateSelfServiceLinks(String signup, String passwd, Model model) {
         Map<String, String> links = (Map<String, String>) model.asMap().get("links");
         validateSelfServiceLinks(signup, passwd, links);

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpointTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpointTests.java
@@ -301,7 +301,7 @@ public class LoginInfoEndpointTests {
 
         //null config
         zone.setConfig(null);
-        validateSelfServiceLinks("/create_account", "/forgot_password", endpoint.getSelfServiceLinks());
+        validateSelfServiceLinks(null, "/forgot_password", endpoint.getSelfServiceLinks());
 
         //null config with globals
         endpoint.setGlobalLinks(new Links().setSelfService(new Links.SelfService().setSignup("/signup").setPasswd("/passwd")));

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/LoginMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/LoginMockMvcTests.java
@@ -237,8 +237,8 @@ public class LoginMockMvcTests extends InjectedMockContextTest {
             .andExpect(status().isOk())
             .andExpect(view().name("login"))
             .andExpect(model().attribute("links", hasEntry("forgotPasswordLink", "/forgot_password")))
-            .andExpect(model().attribute("links", hasEntry("createAccountLink", "/create_account")))
-            .andExpect(content().string(containsString("/create_account")));
+            .andExpect(content().string(containsString("/forgot_password")))
+            .andExpect(content().string(not(containsString("/create_account"))));
 
         getWebApplicationContext().getBean(LoginInfoEndpoint.class).setGlobalLinks(
             new Links().setSelfService(


### PR DESCRIPTION
Unless provided in the config, the create_account link should not show up on login page
forgot password will use the value from the config or default to uaa local forgot_password

Signed-off-by: Arjun <Arjun.Nayak@ge.com>