### PR TITLE
update jenkinsfiles to use dtr and shared lib

### DIFF
--- a/DeployGovCloudJenkinsfile
+++ b/DeployGovCloudJenkinsfile
@@ -1,5 +1,9 @@
 #!/usr/bin/env groovy
 def devcloudArtServer = Artifactory.server('devcloud')
+
+library "security-ci-commons-shared-lib"
+def NODE = nodeDetails("uaa-govcloud")
+
 pipeline {
     agent none
     options {
@@ -19,11 +23,11 @@ pipeline {
             }
             agent {
                 docker {
-                    image 'dig-propel/govcloud-deploy'
-                    label 'dind'
-                    args "--privileged --sysctl net.ipv6.conf.all.disable_ipv6=0"
-                    registryUrl 'https://registry.gear.ge.com/'
-                    registryCredentialsId "DTR_CREDS"
+                    image "${NODE['IMAGE']}"
+                    label "${NODE['LABEL']}"
+                    args "${NODE['ARGS']}"
+                    registryUrl "${NODE['REGISTRY_URL']}"
+                    registryCredentialsId "${NODE['REGISTRY_CREDENTIALS_ID']}"
                 }
             }
 

--- a/DeployJenkinsfile
+++ b/DeployJenkinsfile
@@ -1,5 +1,9 @@
 #!/usr/bin/env groovy
 def devcloudArtServer = Artifactory.server('devcloud')
+
+library "security-ci-commons-shared-lib"
+def NODE = nodeDetails("uaa")
+
 pipeline {
     agent none
     environment {
@@ -18,9 +22,9 @@ pipeline {
         stage('Deploy') {
             agent{
                 docker {
-                    image 'repo.ci.build.ge.com:8443/predix-security/uaa-ci-testing:0.0.8'
-                    label 'dind'
-                    args '-v /var/lib/docker/.gradle:/root/.gradle'
+                    image "${NODE['IMAGE']}"
+                    label "${NODE['LABEL']}"
+                    args "${NODE['ARGS']}"
                 }
             }
             environment {

--- a/DockerizeJenkinsfile
+++ b/DockerizeJenkinsfile
@@ -3,7 +3,7 @@
 pipeline {
     agent {
         docker {
-            image 'repo.ci.build.ge.com:8443/predix-security/uaa-ci-testing-with-docker:latest'
+            image 'registry.gear.ge.com/dig-predix-security-services/uaa-ci-testing-with-docker:latest'
             label 'dind'
             args '-v /var/lib/docker/.gradle:/root/.gradle -v /var/run/docker.sock:/var/run/docker.sock --add-host "localhost":127.0.0.1'
         }

--- a/DocsJenkinsfile
+++ b/DocsJenkinsfile
@@ -1,11 +1,14 @@
 #!/usr/bin/env groovy
 
+library "security-ci-commons-shared-lib"
+def NODE = nodeDetails("uaa")
+
 pipeline {
     agent {
         docker {
-            image 'repo.ci.build.ge.com:8443/predix-security/uaa-ci-testing:0.0.8'
-            label 'dind'
-            args '-v /var/lib/docker/.gradle:/root/.gradle'
+            image "${NODE['IMAGE']}"
+            label "${NODE['LABEL']}"
+            args "${NODE['ARGS']}"
         }
     }
     parameters {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,9 @@
 #!/usr/bin/env groovy
 def devcloudArtServer = Artifactory.server('devcloud')
+
+library "security-ci-commons-shared-lib"
+def NODE = nodeDetails("uaa")
+
 pipeline {
     agent none
     environment {
@@ -21,11 +25,11 @@ pipeline {
             parallel {
                 stage ('Checkout & Build') {
                     agent {
-                      docker {
-                          image 'repo.ci.build.ge.com:8443/predix-security/uaa-ci-testing:0.0.8'
-                          label 'dind'
-                          args '-v /var/lib/docker/.gradle:/root/.gradle'
-                      }
+                        docker {
+                            image "${NODE['IMAGE']}"
+                            label "${NODE['LABEL']}"
+                            args "${NODE['ARGS']}"
+                        }
                     }
                     steps {
                         echo env.BRANCH_NAME
@@ -65,9 +69,9 @@ pipeline {
                     }
                     agent {
                         docker {
-                            image 'repo.ci.build.ge.com:8443/predix-security/uaa-ci-testing:0.0.8'
-                            label 'dind'
-                            args '-v /var/lib/docker/.gradle:/root/.gradle'
+                            image "${NODE['IMAGE']}"
+                            label "${NODE['LABEL']}"
+                            args "${NODE['ARGS']}"
                         }
                     }
                     steps {
@@ -124,9 +128,9 @@ pipeline {
                     }
                     agent {
                         docker {
-                            image 'repo.ci.build.ge.com:8443/predix-security/uaa-ci-testing:0.0.8'
-                            label 'dind'
-                            args '-v /var/lib/docker/.gradle:/root/.gradle'
+                            image "${NODE['IMAGE']}"
+                            label "${NODE['LABEL']}"
+                            args "${NODE['ARGS']}"
                         }
                     }
                     steps {
@@ -189,8 +193,8 @@ pipeline {
                     }
                     agent {
                         docker {
-                            image 'repo.ci.build.ge.com:8443/predix-security/uaa-ci-testing:0.0.8'
-                            label 'dind'
+                            image "${NODE['IMAGE']}"
+                            label "${NODE['LABEL']}"
                             args '-v /var/lib/docker/.gradle:/root/.gradle --add-host "testzone1.localhost testzone2.localhost int-test-zone-uaa.localhost testzone3.localhost testzone4.localhost testzonedoesnotexist.localhost oidcloginit.localhost test-zone1.localhost test-zone2.localhost test-victim-zone.localhost test-platform-zone.localhost test-saml-zone.localhost test-app-zone.localhost app-zone.localhost platform-zone.localhost testsomeother2.ip.com testsomeother.ip.com uaa-acceptance-zone.localhost localhost":127.0.0.1'
                         }
                     }
@@ -259,11 +263,11 @@ pipeline {
                         ADMIN_CLIENT_SECRET = credentials("ADMIN_CLIENT_SECRET_CF3_INTEGRATION")
                     }
                     agent {
-                       docker {
-                           image 'repo.ci.build.ge.com:8443/predix-security/uaa-ci-testing:0.0.8'
-                           label 'dind'
-                           args '-v /var/lib/docker/.gradle:/root/.gradle'
-                       }
+                        docker {
+                            image "${NODE['IMAGE']}"
+                            label "${NODE['LABEL']}"
+                            args "${NODE['ARGS']}"
+                        }
                     }
                     steps {
                         echo env.BRANCH_NAME


### PR DESCRIPTION
Shared lib created by Sebastian: https://github.build.ge.com/predix/security-ci-commons/blob/master/vars/nodeDetails.groovy 
To use it, you need to set up each job to pull the shared lib and then call it in the Jenkinsfile based on the env. This is helpful to have when you want to use shared values across Jenkinsfiles (e.g. govcloud deployments for uaa, dashboard, service broker, etc) For this PR, we're sharing the docker agent config.