### PR TITLE
Allow SCIM filtering by external_id

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/resources/jdbc/SimpleSearchQueryConverter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/resources/jdbc/SimpleSearchQueryConverter.java
@@ -93,7 +93,8 @@ public class SimpleSearchQueryConverter implements SearchQueryConverter {
             "gm.external_group",
             "gm.origin",
             "g.displayname",
-            "g.id"
+            "g.id",
+            "external_id"
         )
     );
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/resources/jdbc/SimpleSearchQueryConverterTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/resources/jdbc/SimpleSearchQueryConverterTests.java
@@ -53,6 +53,8 @@ public class SimpleSearchQueryConverterTests {
 
     String validQuery = "user_id eq \"7e2345e8-8bbf-4eaa-9bc3-ae1ba610f890\"" +
         "and " +
+        "external_id eq \"2b0640e9-2b45-4d61-ab55-48b96e06e812\"" +
+        "and " +
         "client_id eq \"app\"" +
         "and " +
         "meta.lastmodified gt \"some-value\"" +

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimUserEndpointsTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimUserEndpointsTests.java
@@ -208,8 +208,10 @@ public class ScimUserEndpointsTests {
 
         joel = new ScimUser(null, "jdsa", "Joel", "D'sa");
         joel.addEmail(JDSA_VMWARE_COM);
+        joel.setExternalId("b2f345ee-d893-44a9-b6ee-0abe865ff886");
         dale = new ScimUser(null, "olds", "Dale", "Olds");
         dale.addEmail("olds@vmware.com");
+        dale.setExternalId("dc2d1cdf-15a1-4faf-8320-07eb8e8f864d");
         joel = dao.createUser(joel, "password", IdentityZoneHolder.get().getId());
         dale = dao.createUser(dale, "password", IdentityZoneHolder.get().getId());
 
@@ -794,6 +796,15 @@ public class ScimUserEndpointsTests {
         SearchResults<?> results = endpoints.findUsers("id", "userName eq \"jdsa\"", null, "ascending", 1, 100);
         assertEquals(1, results.getTotalResults());
         assertEquals(1, results.getSchemas().size()); // System.err.println(results.getValues());
+        assertEquals(joel.getId(), ((Map<String, Object>) results.getResources().iterator().next()).get("id"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testFindIdsByExternalId() {
+        SearchResults<?> results = endpoints.findUsers("id", "external_id eq \"b2f345ee-d893-44a9-b6ee-0abe865ff886\"", null, "ascending", 1, 100);
+        assertEquals(1, results.getTotalResults());
+        assertEquals(1, results.getSchemas().size());
         assertEquals(joel.getId(), ((Map<String, Object>) results.getResources().iterator().next()).get("id"));
     }
 


### PR DESCRIPTION
## Summary
- [x] Add filtering by `external_id` to the SCIM `/Users` endpoint that addresses [issue #900 on `cloudfoundry/uaa`](https://github.com/cloudfoundry/uaa/issues/900). A sample request is:
  ```bash
  $ http \
      GET 'http://localhost:8080/uaa/Users?filter=external_id%20eq%20%22test-user%22' \
      'Authorization':'Bearer [REDACTED]' \
      'Accept':'application/json'
  ```
- [x] Add the necessary unit tests

## Affected Tests
```bash
$ ./gradlew :cloudfoundry-identity-server:test \
    --tests org.cloudfoundry.identity.uaa.scim.endpoints.ScimUserEndpointsTests
$ ./gradlew :cloudfoundry-identity-server:test \
    --tests org.cloudfoundry.identity.uaa.resources.jdbc.SimpleSearchQueryConverterTests
```