### PR TITLE
Log whitelisted audit event types at DEBUG level

### DIFF
--- a/server/src/test/java/org/cloudfoundry/identity/uaa/audit/LoggingAuditServiceTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/audit/LoggingAuditServiceTest.java
@@ -5,23 +5,38 @@ import org.apache.commons.logging.Log;
 import org.cloudfoundry.identity.uaa.logging.LogSanitizerUtil;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import static org.cloudfoundry.identity.uaa.audit.AuditEventType.ClientAuthenticationFailure;
+import static org.cloudfoundry.identity.uaa.audit.AuditEventType.ClientAuthenticationSuccess;
 import static org.cloudfoundry.identity.uaa.audit.AuditEventType.PasswordChangeFailure;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = { LoggingAuditServiceTest.ContextConfiguration.class, LoggingAuditService.class })
+@TestPropertySource(properties = { "AUDIT_EVENT_TYPES_DEBUG=ClientAuthenticationSuccess,ClientAuthenticationFailure" })
 public class LoggingAuditServiceTest {
 
+    @Autowired
     private LoggingAuditService loggingAuditService;
+
     private Log mockLogger;
 
     @Before
     public void setup() {
-        loggingAuditService = new LoggingAuditService();
         mockLogger = mock(Log.class);
-        loggingAuditService.setLogger(mockLogger);
+        ReflectionTestUtils.setField(loggingAuditService, "logger", mockLogger);
     }
 
     @Test
@@ -47,5 +62,36 @@ public class LoggingAuditServiceTest {
         ArgumentCaptor<String> stringCaptor = ArgumentCaptor.forClass(String.class);
         verify(mockLogger).info(stringCaptor.capture());
         assertFalse(stringCaptor.getValue().contains(LogSanitizerUtil.SANITIZED_FLAG));
+    }
+
+    @Test
+    public void log_outputsClientAuthenticationSuccessEventTypeAtDebugLevel() {
+        AuditEvent auditEvent = new AuditEvent(ClientAuthenticationSuccess, "principalId", "origin", "data", 100L, "not-used", null, null);
+
+        loggingAuditService.log(auditEvent, "not-used");
+
+        ArgumentCaptor<String> stringCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mockLogger).debug(stringCaptor.capture());
+        assertFalse(stringCaptor.getValue().contains(LogSanitizerUtil.SANITIZED_FLAG));
+    }
+
+    @Test
+    public void log_outputsClientAuthenticationFailureEventTypeAtDebugLevel() {
+        AuditEvent auditEvent = new AuditEvent(ClientAuthenticationFailure, "principalId", "origin", "data", 100L, "not-used", null, null);
+
+        loggingAuditService.log(auditEvent, "not-used");
+
+        ArgumentCaptor<String> stringCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mockLogger).debug(stringCaptor.capture());
+        assertFalse(stringCaptor.getValue().contains(LogSanitizerUtil.SANITIZED_FLAG));
+    }
+
+    @Configuration
+    static class ContextConfiguration {
+
+        @Bean
+        public static PropertySourcesPlaceholderConfigurer propertySourcesPlaceholderConfigurer() {
+            return new PropertySourcesPlaceholderConfigurer();
+        }
     }
 }


### PR DESCRIPTION
**Summary**: Log certain audit event types at `DEBUG` level to reduce the amount of logs generated in a production environment that usu. has its log level set to `INFO` or higher.

**Changes**:
- [x] Only log audit event types whitelisted through the configurable, comma-separated environment variable `AUDIT_EVENT_TYPES_DEBUG` at the `DEBUG` level.
- [x] Add unit tests that set the `AUDIT_EVENT_TYPES_DEBUG` property to `ClientAuthenticationSuccess,ClientAuthenticationFailure` and ascertain that events of both types are logged at the `DEBUG` level.