### PR TITLE
Modify jwt auth requestUrl scheme based on x-scheme

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/token/JwtBearerAssertionAuthenticationFilter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/token/JwtBearerAssertionAuthenticationFilter.java
@@ -105,8 +105,20 @@ public class JwtBearerAssertionAuthenticationFilter extends OncePerRequestFilter
     }
 
     private Authentication authenticateJwtAssertion(final HttpServletRequest request, String jwtAssertion) {
+        String requestUrl = request.getRequestURL().toString();
+        String requestScheme = request.getHeader("x-scheme");
+
+        if (requestScheme != null) {
+            StringBuffer modifiedRequestUrl = new StringBuffer();
+            modifiedRequestUrl.append(requestScheme);
+            modifiedRequestUrl.append("://");
+            modifiedRequestUrl.append(request.getServerName());
+            modifiedRequestUrl.append(request.getRequestURI()); rl = modifiedRequestUrl.toString();
+                    
+        }
+        
         JwtBearerAssertionTokenAuthenticator tokenAuthenticator = new JwtBearerAssertionTokenAuthenticator(
-                request.getRequestURL().toString(), this.clientAssertionHeaderTTL);
+                requestUrl, this.clientAssertionHeaderTTL);
         tokenAuthenticator.setClientDetailsService(this.clientDetailsService);
         tokenAuthenticator.setClientPublicKeyProvider(this.publicKeyProvider);
         tokenAuthenticator.setDcsEndpointTokenGranter(this.dcsEndpointTokenGranter);


### PR DESCRIPTION
This PR updates the scheme of the requestUrl used to initialize `JwtBearerAssertionTokenAuthenticator` to match the x-scheme of the original call by the device.

Fix applied to em-onprem deployment of uaa. 

`JwtBearerAssertionTokenAuthenticator` is currently initiated with `http://uaa...` based on incoming request.  The headers x-forwarded-protocol and x-forwarded-host were not recieved as part of the request, despite being added by ingress-nginx. 

Device sending jwt token with uaa audience `https://uaa...` but  fails audience comparison against `http://uaa...`. Devices fails to acquire access token as a result. 

Fix was based on ge_4.10.2 tag.