### PR TITLE
[US393567] Update artifactory from devcloud to build.ge

### DIFF
--- a/DeployGovCloudJenkinsfile
+++ b/DeployGovCloudJenkinsfile
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-def devcloudArtServer = Artifactory.server('devcloud')
+def buildGeArtServer = Artifactory.server('build.ge')
 
 library "security-ci-commons-shared-lib"
 def NODE = nodeDetails("uaa-govcloud")
@@ -45,12 +45,12 @@ pipeline {
                             {
                                 "target": "deploy-workspace/",
                                 "flat": "true",
-                                "pattern": "MAAXA-MVN/builds/uaa/${APP_VERSION}/*.war"
+                                "pattern": "MAAXA/builds/uaa/${APP_VERSION}/*.war"
                             }
                         ]
                     }"""
                     sh 'pwd && ls -ltr'
-                    devcloudArtServer.download(downloadSpec)
+                    buildGeArtServer.download(downloadSpec)
                     sh "ls -ltr deploy-workspace/"
                     dir('uaa-cf-release') {
                         git changelog: false, credentialsId: 'github.build.ge.com', poll: false, url: 'https://github.build.ge.com/predix/uaa-cf-release.git', branch: 'master'

--- a/DeployJenkinsfile
+++ b/DeployJenkinsfile
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-def devcloudArtServer = Artifactory.server('devcloud')
+def buildGeArtServer = Artifactory.server('build.ge')
 
 library "security-ci-commons-shared-lib"
 def NODE = nodeDetails("uaa")
@@ -45,12 +45,12 @@ pipeline {
                             {
                                 "target": "deploy-workspace/",
                                 "flat": "true",
-                                "pattern": "MAAXA-MVN/builds/uaa/${APP_VERSION}/*.war"
+                                "pattern": "MAAXA/builds/uaa/${APP_VERSION}/*.war"
                             }
                         ]
                     }"""
                     sh 'pwd && ls -ltr'
-                    devcloudArtServer.download(downloadSpec)
+                    buildGeArtServer.download(downloadSpec)
                     sh "ls -ltr deploy-workspace/"
                 }
                 dir('uaa-cf-release') {
@@ -127,12 +127,12 @@ pipeline {
                         "files": [
                             {
                                 "pattern": "deploy-workspace/cloudfoundry-identity-uaa-${APP_VERSION}.war",
-                                "target": "MAAXA-MVN/org/cloudfoundry/identity/cloudfoundry-identity-uaa/${APP_VERSION}/"
+                                "target": "MAAXA/org/cloudfoundry/identity/cloudfoundry-identity-uaa/${APP_VERSION}/"
                             }
                         ]
                     }"""
-                    def buildInfo = devcloudArtServer.upload(uploadSpec)
-                    devcloudArtServer.publishBuildInfo(buildInfo)
+                    def buildInfo = buildGeArtServer.upload(uploadSpec)
+                    buildGeArtServer.publishBuildInfo(buildInfo)
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-def devcloudArtServer = Artifactory.server('devcloud')
+def buildGeArtServer = Artifactory.server('build.ge')
 
 @Library(['PPCmanifest','security-ci-commons-shared-lib']) _
 def NODE = nodeDetails("uaa")
@@ -23,7 +23,7 @@ pipeline {
         booleanParam(name: 'MOCK_MVC_TESTS', defaultValue: true, description: 'Run Mock MVC tests')
         booleanParam(name: 'INTEGRATION_TESTS', defaultValue: true, description: 'Run Integration tests')
         booleanParam(name: 'DEGRADED_TESTS', defaultValue: true, description: 'Run degraded mode tests')
-        booleanParam(name: 'PUSH_TO_DEVCLOUD', defaultValue: false, description: 'Publish to build artifactory')
+        booleanParam(name: 'PUSH_TO_BUILD_GE', defaultValue: false, description: 'Publish to build artifactory')
     }
     stages {
         stage('Build and run Tests') {
@@ -399,7 +399,7 @@ pipeline {
                 label 'dind'
             }
             when {
-                expression { params.PUSH_TO_DEVCLOUD == true }
+                expression { params.PUSH_TO_BUILD_GE == true }
             }
             steps{
                 dir('uaa') {
@@ -422,12 +422,12 @@ pipeline {
                        "files": [
                            {
                                "pattern": "build/cloudfoundry-identity-uaa-${APP_VERSION}.war",
-                               "target": "MAAXA-MVN/builds/uaa/${APP_VERSION}/"
+                               "target": "MAAXA/builds/uaa/${APP_VERSION}/"
                            }
                        ]
                     }"""
-                    def buildInfo = devcloudArtServer.upload(uploadSpec)
-                    devcloudArtServer.publishBuildInfo(buildInfo)
+                    def buildInfo = buildGeArtServer.upload(uploadSpec)
+                    buildGeArtServer.publishBuildInfo(buildInfo)
 
                     BINTRAY_LOCATION = "https://api.bintray.com/content/gedigital/Rosneft/uaa/${APP_VERSION}"
                     echo "BINTRAY_LOCATION=${BINTRAY_LOCATION}"

--- a/build.gradle
+++ b/build.gradle
@@ -71,14 +71,7 @@ allprojects {
                 username geArtifactoryReader
                 password geArtifactoryReaderPassword
             }
-            url 'https://devcloud.swcoe.ge.com/artifactory/PREDIX'
-        }
-        maven {
-            credentials {
-              username geArtifactoryReader
-              password geArtifactoryReaderPassword
-            }
-            url 'https://devcloud.swcoe.ge.com/artifactory/PREDIX-SNAPSHOT'
+            url 'https://artifactory.build.ge.com/predix-virtual'
         }
         maven {
             url 'https://build.shibboleth.net/nexus/content/repositories/releases/'
@@ -187,15 +180,7 @@ subprojects {
                 username geArtifactoryReader
                 password geArtifactoryReaderPassword
             }
-            url 'https://devcloud.swcoe.ge.com/artifactory/PREDIX'
-        }
-
-        maven {
-            credentials {
-                username geArtifactoryReader
-                password geArtifactoryReaderPassword
-            }
-            url 'https://devcloud.swcoe.ge.com/artifactory/PREDIX-SNAPSHOT'
+            url 'https://artifactory.build.ge.com/predix-virtual'
         }
     }
 


### PR DESCRIPTION
[US393567](https://rally1.rallydev.com/#/detail/userstory/361940107604?fdp=true): Migrate UAA/UAA Dashboard from DevCloud Artifactory to new Build.GE Artifactory

Passing Build: https://i.ci.build.ge.com/bjmjek1k/ci/job/UAA/job/Build%20n%20Test/job/update-artifactory/15/

Uploaded Artifact: https://artifactory.build.ge.com/webapp/#/artifacts/browse/tree/General/MAAXA/builds/uaa/4.30.0-test