### PR TITLE
[US459522] Fix UAA pipeline failures

### DIFF
--- a/DeployJenkinsfile
+++ b/DeployJenkinsfile
@@ -68,8 +68,6 @@ pipeline {
                 source uaa-cf-release/config-${DEPLOYMENT_TYPE}/set-env.sh
                 unset_env
 
-                install_chromedriver
-
                 pushd uaa-cf-release
                     source combine-inline-config.sh
                     echo "$UAA_CONFIG_YAML"

--- a/DockerizeJenkinsfile
+++ b/DockerizeJenkinsfile
@@ -7,7 +7,7 @@ def use_release_artifacts() {
 pipeline {
     agent {
         docker {
-            image 'registry.gear.ge.com/dig-predix-security-services/uaa-ci-testing:latest'
+            image 'registry.gear.ge.com/dig-predix-security-services/uaa-ci-testing:1.1.0'
             label 'dind'
             args '-v /var/lib/docker/.gradle:/root/.gradle -v /var/run/docker.sock:/var/run/docker.sock --add-host "localhost":127.0.0.1'
         }
@@ -60,8 +60,6 @@ pipeline {
                     source uaa/scripts/setup-tests.sh
                     source uaa-cf-release/config-local/set-env.sh
                     unset_env
-
-                    install_chromedriver
 
                     pushd uaa
                         export UAA_HOST=localhost

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -220,12 +220,8 @@ pipeline {
 
                             curl -v http://simplesamlphp.uaa-acceptance.cf-app.com/saml2/idp/metadata.php
 
-                            install_chromedriver
-
-                            ### install ldap
-                            apt-get -y update || echo "problems were encountered when trying to update the package index, but let's continue anyway"
-                            DEBIAN_FRONTEND=noninteractive apt-get -qy install slapd ldap-utils
-                            /etc/init.d/slapd start 
+                            ### start slapd and add entries to ldap for tests
+                            /etc/init.d/slapd start
                             /etc/init.d/slapd status
                             ldapadd -Y EXTERNAL -H ldapi:/// -f uaa/uaa/src/main/resources/ldap_db_init.ldif
                             ldapadd -x -D 'cn=admin,dc=test,dc=com' -w password -f uaa/uaa/src/main/resources/ldap_init.ldif
@@ -313,19 +309,13 @@ pipeline {
                                     export APP_VERSION=`grep 'version' uaa/gradle.properties | sed 's/version=//'`
                                     unset_env
 
-                                    install_chromedriver
-
                                     ruby -v
 
                                     # The docker image comes with uaac version 4.1.0, which is fine.
                                     # DO NOT upgrade to 4.2.0, for that version url-encodes special characters, turning
                                     # admin secret abc@def into abc%40def, which leads to a "Bad credentials"
-                                    # authenication failure.
+                                    # authentication failure.
                                     uaac --version
-
-                                    #install phantomjs for degraded tests
-                                    gem install phantomjs
-                                    phantomjs --version
 
                                     apt-get install jq -y
                                     jq --version

--- a/scripts/setup-tests.sh
+++ b/scripts/setup-tests.sh
@@ -12,14 +12,3 @@ unset_env() {
   unset PROXY_HOST
   env
 }
-
-install_chromedriver() {
-  wget --quiet 'https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/Linux_x64%2F665006%2Fchromedriver_linux64.zip?generation=1559267957115896&alt=media'
-  wget --quiet 'https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/Linux_x64%2F665006%2Fchrome-linux.zip?generation=1559267949433976&alt=media'
-  unzip -o 'Linux_x64%2F665006%2Fchromedriver_linux64.zip?generation=1559267957115896&alt=media'
-  unzip -o 'Linux_x64%2F665006%2Fchrome-linux.zip?generation=1559267949433976&alt=media'
-  ln -s $PWD/chromedriver_linux64/chromedriver /usr/bin/
-  ln -s $PWD/chrome-linux/chrome /usr/bin/
-  chromedriver --version
-  chrome --version
-}


### PR DESCRIPTION
Fix UAA Jenkins failures

- moved chromedriver and ldap installation to uaa-ci-testing docker image

Successful build: https://i.ci.build.ge.com/bjmjek1k/ci/job/UAA/job/Build%20n%20Test/view/change-requests/job/PR-187/2/