### PR TITLE
Update Jenkins jobs to retain 15 builds up to 90 days

### DIFF
--- a/AcceptanceGovCloudJenkinsfile
+++ b/AcceptanceGovCloudJenkinsfile
@@ -8,7 +8,8 @@ pipeline {
     agent none
     options {
         skipDefaultCheckout()
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '1', artifactNumToKeepStr: '1', daysToKeepStr: '5', numToKeepStr: '10'))
+        buildDiscarder(logRotator(artifactNumToKeepStr: '15', numToKeepStr: '15', artifactDaysToKeepStr: '90',
+                daysToKeepStr: '90'))
     }
     stages {
         stage('Run acceptance tests in govcloud') {

--- a/AnalysisJenkinsfile
+++ b/AnalysisJenkinsfile
@@ -7,7 +7,8 @@ pipeline {
     }
     options {
         skipDefaultCheckout()
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '1', artifactNumToKeepStr: '1', daysToKeepStr: '5', numToKeepStr: '10'))
+        buildDiscarder(logRotator(artifactNumToKeepStr: '15', numToKeepStr: '15', artifactDaysToKeepStr: '90',
+                daysToKeepStr: '90'))
     }
     parameters {
         booleanParam(name: 'WHITESOURCE_SCAN', defaultValue: true, description: 'Run Whitesource scan')

--- a/DeployGovCloudJenkinsfile
+++ b/DeployGovCloudJenkinsfile
@@ -8,7 +8,8 @@ pipeline {
     agent none
     options {
         skipDefaultCheckout()
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '1', artifactNumToKeepStr: '1', daysToKeepStr: '5', numToKeepStr: '10'))
+        buildDiscarder(logRotator(artifactNumToKeepStr: '15', numToKeepStr: '15', artifactDaysToKeepStr: '90',
+                daysToKeepStr: '90'))
     }
     parameters  {
         choice(name: 'DEPLOYMENT_TYPE', choices:'govw', description: 'This specifies which point of presence to deploy to')

--- a/DeployJenkinsfile
+++ b/DeployJenkinsfile
@@ -11,7 +11,8 @@ pipeline {
     }
     options {
         skipDefaultCheckout()
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '1', artifactNumToKeepStr: '1', daysToKeepStr: '5', numToKeepStr: '10'))
+        buildDiscarder(logRotator(artifactNumToKeepStr: '15', numToKeepStr: '15', artifactDaysToKeepStr: '90',
+                daysToKeepStr: '90'))
     }
     parameters  {
         choice(name: 'DEPLOYMENT_TYPE', choices:'cf3-release-candidate\ncf3-staging\ncf3-integration\nvpc\neu-central\ngovw\nperf-cf3', description: 'This specifies which point of presence to deploy to')

--- a/DocsJenkinsfile
+++ b/DocsJenkinsfile
@@ -20,7 +20,8 @@ pipeline {
     options {
         timestamps()
         skipDefaultCheckout()
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '1', artifactNumToKeepStr: '1', daysToKeepStr: '5', numToKeepStr: '10'))
+        buildDiscarder(logRotator(artifactNumToKeepStr: '15', numToKeepStr: '15', artifactDaysToKeepStr: '90',
+                daysToKeepStr: '90'))
     }
     stages {
         stage('Build Docs') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,8 @@ pipeline {
     }
     options {
         skipDefaultCheckout()
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '1', artifactNumToKeepStr: '1', daysToKeepStr: '5', numToKeepStr: '10'))
+        buildDiscarder(logRotator(artifactNumToKeepStr: '15', numToKeepStr: '15', artifactDaysToKeepStr: '90',
+                daysToKeepStr: '90'))
     }
     parameters {
         booleanParam(name: 'UNIT_TESTS', defaultValue: true, description: 'Run Unit tests')

--- a/PPCDeployJenkinsfile
+++ b/PPCDeployJenkinsfile
@@ -8,7 +8,8 @@ pipeline {
     }
     options {
         skipDefaultCheckout()
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '1', artifactNumToKeepStr: '1', daysToKeepStr: '5', numToKeepStr: '10'))
+        buildDiscarder(logRotator(artifactNumToKeepStr: '15', numToKeepStr: '15', artifactDaysToKeepStr: '90',
+                daysToKeepStr: '90'))
     }
     parameters  {
         choice(name: 'DEPLOYMENT_TYPE', choices:'sr-lab,rosneft-jv-stg,rosneft-jv-dev', description: 'This specifies which point of presence to deploy to')


### PR DESCRIPTION
Current setting of 5 days for builds isn't long enough and results in
only the last build being kept in history. This makes it hard to see
when past deployments happened for instance.

Update Jenkinsfiles to change jobs to retain a maximum of 15 builds for
a maximum of 90 days.