### PR TITLE
Fix artifactory upload for deploy builds for staging environment

### DIFF
--- a/DeployJenkinsfile
+++ b/DeployJenkinsfile
@@ -142,6 +142,7 @@ pipeline {
                 }
 
                 script {
+                    def util = load('uaa/JenkinsfileCommon.groovy')
                     APP_VERSION = util.getAppVersion()
                     echo "Publishing UAA ${APP_VERSION} Artifact to Artifactory"
                     def uploadSpec = """{


### PR DESCRIPTION
After deployment, just for staging environments, the deploy job uploads
the deployed .war file to artifactory. This was broken by refactoring in
commit 0610a7b66 - scope for utility loaded was restricted to stage it
was loaded in, and so it isn't available in this separate stage to
upload artifacts.

Fix by loading the utility file again in the upload stage.