### PR TITLE
Re-fix artifactory upload after deploy to staging

### DIFF
--- a/DeployJenkinsfile
+++ b/DeployJenkinsfile
@@ -141,6 +141,10 @@ pipeline {
                     unstash 'uaa-war'
                 }
 
+                dir('uaa') {
+                    checkout scm
+                }
+
                 script {
                     def util = load('uaa/JenkinsfileCommon.groovy')
                     APP_VERSION = util.getAppVersion()


### PR DESCRIPTION
Since its a different stage in a different container, uaa needs to be
checked out again for loading the common utility script used to figure
out the UAA version.