### PR TITLE
Update log4j version to 2.17.1

### DIFF
--- a/AcceptanceGovCloudJenkinsfile
+++ b/AcceptanceGovCloudJenkinsfile
@@ -7,6 +7,7 @@ def NODE = nodeDetails("uaa-govcloud")
 pipeline {
     agent none
     options {
+        timestamps()
         skipDefaultCheckout()
         buildDiscarder(logRotator(artifactNumToKeepStr: '15', numToKeepStr: '15', artifactDaysToKeepStr: '90',
                 daysToKeepStr: '90'))

--- a/AcceptanceGovCloudJenkinsfile
+++ b/AcceptanceGovCloudJenkinsfile
@@ -9,8 +9,7 @@ pipeline {
     options {
         timestamps()
         skipDefaultCheckout()
-        buildDiscarder(logRotator(artifactNumToKeepStr: '15', numToKeepStr: '15', artifactDaysToKeepStr: '90',
-                daysToKeepStr: '90'))
+        buildDiscarder(logRotator(artifactNumToKeepStr: '30', numToKeepStr: '30'))
     }
     stages {
         stage('Run acceptance tests in govcloud') {

--- a/AnalysisJenkinsfile
+++ b/AnalysisJenkinsfile
@@ -8,8 +8,7 @@ pipeline {
     options {
         timestamps()
         skipDefaultCheckout()
-        buildDiscarder(logRotator(artifactNumToKeepStr: '15', numToKeepStr: '15', artifactDaysToKeepStr: '90',
-                daysToKeepStr: '90'))
+        buildDiscarder(logRotator(artifactNumToKeepStr: '30', numToKeepStr: '30'))
     }
     parameters {
         booleanParam(name: 'WHITESOURCE_SCAN', defaultValue: true, description: 'Run Whitesource scan')

--- a/AnalysisJenkinsfile
+++ b/AnalysisJenkinsfile
@@ -6,6 +6,7 @@ pipeline {
         cron('H 22 1 * *')
     }
     options {
+        timestamps()
         skipDefaultCheckout()
         buildDiscarder(logRotator(artifactNumToKeepStr: '15', numToKeepStr: '15', artifactDaysToKeepStr: '90',
                 daysToKeepStr: '90'))

--- a/DeployGovCloudJenkinsfile
+++ b/DeployGovCloudJenkinsfile
@@ -9,8 +9,7 @@ pipeline {
     options {
         timestamps()
         skipDefaultCheckout()
-        buildDiscarder(logRotator(artifactNumToKeepStr: '15', numToKeepStr: '15', artifactDaysToKeepStr: '90',
-                daysToKeepStr: '90'))
+        buildDiscarder(logRotator(artifactNumToKeepStr: '30', numToKeepStr: '30'))
     }
     parameters  {
         choice(name: 'DEPLOYMENT_TYPE', choices:'govw', description: 'This specifies which point of presence to deploy to')

--- a/DeployGovCloudJenkinsfile
+++ b/DeployGovCloudJenkinsfile
@@ -7,6 +7,7 @@ def NODE = nodeDetails("uaa-govcloud")
 pipeline {
     agent none
     options {
+        timestamps()
         skipDefaultCheckout()
         buildDiscarder(logRotator(artifactNumToKeepStr: '15', numToKeepStr: '15', artifactDaysToKeepStr: '90',
                 daysToKeepStr: '90'))

--- a/DeployJenkinsfile
+++ b/DeployJenkinsfile
@@ -10,6 +10,7 @@ pipeline {
         COMPLIANCEENABLED = true
     }
     options {
+        timestamps()
         skipDefaultCheckout()
         buildDiscarder(logRotator(artifactNumToKeepStr: '15', numToKeepStr: '15', artifactDaysToKeepStr: '90',
                 daysToKeepStr: '90'))

--- a/DeployJenkinsfile
+++ b/DeployJenkinsfile
@@ -12,8 +12,7 @@ pipeline {
     options {
         timestamps()
         skipDefaultCheckout()
-        buildDiscarder(logRotator(artifactNumToKeepStr: '15', numToKeepStr: '15', artifactDaysToKeepStr: '90',
-                daysToKeepStr: '90'))
+        buildDiscarder(logRotator(artifactNumToKeepStr: '30', numToKeepStr: '30'))
     }
     parameters  {
         choice(name: 'DEPLOYMENT_TYPE', choices:'cf3-release-candidate\ncf3-staging\ncf3-integration\nvpc\neu-central\ngovw\nperf-cf3', description: 'This specifies which point of presence to deploy to')

--- a/DockerizeJenkinsfile
+++ b/DockerizeJenkinsfile
@@ -17,6 +17,7 @@ pipeline {
         COMPLIANCEENABLED = true
     }
     options {
+        timestamps()
         skipDefaultCheckout()
         buildDiscarder(logRotator(artifactDaysToKeepStr: '1', artifactNumToKeepStr: '1', daysToKeepStr: '5', numToKeepStr: '10'))
     }

--- a/DockerizeJenkinsfile
+++ b/DockerizeJenkinsfile
@@ -19,7 +19,7 @@ pipeline {
     options {
         timestamps()
         skipDefaultCheckout()
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '1', artifactNumToKeepStr: '1', daysToKeepStr: '5', numToKeepStr: '10'))
+        buildDiscarder(logRotator(artifactNumToKeepStr: '30', numToKeepStr: '30'))
     }
     stages {
         stage('Cleanup Docker Containers') {

--- a/DocsJenkinsfile
+++ b/DocsJenkinsfile
@@ -20,8 +20,7 @@ pipeline {
     options {
         timestamps()
         skipDefaultCheckout()
-        buildDiscarder(logRotator(artifactNumToKeepStr: '15', numToKeepStr: '15', artifactDaysToKeepStr: '90',
-                daysToKeepStr: '90'))
+        buildDiscarder(logRotator(artifactNumToKeepStr: '30', numToKeepStr: '30'))
     }
     stages {
         stage('Build Docs') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,6 +10,7 @@ pipeline {
         COMPLIANCEENABLED = true
     }
     options {
+        timestamps()
         skipDefaultCheckout()
         buildDiscarder(logRotator(artifactNumToKeepStr: '15', numToKeepStr: '15', artifactDaysToKeepStr: '90',
                 daysToKeepStr: '90'))

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,8 +12,7 @@ pipeline {
     options {
         timestamps()
         skipDefaultCheckout()
-        buildDiscarder(logRotator(artifactNumToKeepStr: '15', numToKeepStr: '15', artifactDaysToKeepStr: '90',
-                daysToKeepStr: '90'))
+        buildDiscarder(logRotator(artifactNumToKeepStr: '30', numToKeepStr: '30'))
     }
     parameters {
         booleanParam(name: 'UNIT_TESTS', defaultValue: true, description: 'Run Unit tests')

--- a/PPCDeployJenkinsfile
+++ b/PPCDeployJenkinsfile
@@ -9,8 +9,7 @@ pipeline {
     options {
         timestamps()
         skipDefaultCheckout()
-        buildDiscarder(logRotator(artifactNumToKeepStr: '15', numToKeepStr: '15', artifactDaysToKeepStr: '90',
-                daysToKeepStr: '90'))
+        buildDiscarder(logRotator(artifactNumToKeepStr: '30', numToKeepStr: '30'))
     }
     parameters  {
         choice(name: 'DEPLOYMENT_TYPE', choices:'sr-lab,rosneft-jv-stg,rosneft-jv-dev', description: 'This specifies which point of presence to deploy to')

--- a/PPCDeployJenkinsfile
+++ b/PPCDeployJenkinsfile
@@ -7,6 +7,7 @@ pipeline {
         COMPLIANCEENABLED = true
     }
     options {
+        timestamps()
         skipDefaultCheckout()
         buildDiscarder(logRotator(artifactNumToKeepStr: '15', numToKeepStr: '15', artifactDaysToKeepStr: '90',
                 daysToKeepStr: '90'))

--- a/PublishBintrayJenkinsfile
+++ b/PublishBintrayJenkinsfile
@@ -10,6 +10,7 @@ pipeline {
     }
 
     options {
+        timestamps()
         skipDefaultCheckout()
     }
 

--- a/PublishBintrayJenkinsfile
+++ b/PublishBintrayJenkinsfile
@@ -12,6 +12,7 @@ pipeline {
     options {
         timestamps()
         skipDefaultCheckout()
+        buildDiscarder(logRotator(artifactNumToKeepStr: '30', numToKeepStr: '30'))
     }
 
     environment {

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -6,7 +6,7 @@ ext {
 // Versions we're overriding from the Spring Boot Bom
 ext["mariadb.version"] = "2.3.0"
 ext["flyway.version"] = "5.2.4"
-ext['log4j2.version'] = "2.17.0"
+ext['log4j2.version'] = "2.17.1"
 
 // Versions shared between multiple dependencies
 versions.aspectJVersion = "1.9.4"
@@ -124,7 +124,7 @@ libraries.jakartaEl = "org.glassfish:jakarta.el:${versions.jakartaElVersion}"
 libraries.springMeteringFilter = "com.ge.predix:spring-metering-filter:2.0.0"
 libraries.nurego = "com.nurego:nurego-java:2.1"
 libraries.predixAudit = "com.ge.predix.audit:audit-sdk:0.0.6"
-libraries.springLogFilter = "com.ge.predix:spring-log-filter:3.0.3"
+libraries.springLogFilter = "com.ge.predix:spring-log-filter:3.0.4"
 libraries.splunkObservability = "com.splunk:splunk-otel-javaagent:1.4.0"
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=75.6.2
+version=75.6.3
 
 # Required for LdapMockMvcTests when asserting it can find a user in a different language
 org.gradle.jvmargs=-Dfile.encoding=utf8 -XX:+StartAttachListener -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/uaa-tests.hprof


### PR DESCRIPTION
Fixes another vulnerability still present in log4j, CVE-2021-44832 [1]

- Update log4j version in dependencies.gradle to be `2.17.1`
- Update spring-log-filter version to `3.0.4`, which also has been updated
  to use log4j `2.17.1` [2]
- Update uaa version in gradle.properties to bump it to `75.6.3`

[1] https://logging.apache.org/log4j/2.x/security.html
[2] https://github.com/predix/spring-log-filter/commit/7155e82c9f3c02a0bd78603eb2c213967c9a9ad4