### PR TITLE
Update method to specify UAA URL for JWT Bearer grant tests

### DIFF
--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/acceptance/JwtBearerGrantAT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/acceptance/JwtBearerGrantAT.java
@@ -70,11 +70,8 @@ public class JwtBearerGrantAT {
     @Value("${KEY_PROVIDER_SERVICE_URL:not-used}")
     String keyProviderServiceUrl;
 
-    @Value("${UAA_HOST:}")
-    String uaaHost;
-
-    @Value("${UAA_PORT:}")
-    String uaaPort;
+    @Value("${UAA_ROUTE:}")
+    String uaaRoute;
 
     @Value("${UAA_PATH:}")
     String uaaPath;
@@ -93,7 +90,7 @@ public class JwtBearerGrantAT {
 
         if (this.runAgainstLocalUaa) {
             String path = StringUtils.isEmpty(this.uaaPath) ? "" : "/" + this.uaaPath;
-            this.acceptanceZoneUrl = "http://" + this.zoneSubdomain + "." + this.uaaHost + ":" + this.uaaPort + path;
+            this.acceptanceZoneUrl = "http://" + this.zoneSubdomain + "." + this.uaaRoute + path;
         }
         else {
             this.acceptanceZoneUrl = "https://" + this.zoneSubdomain + "."  + this.publishedHost + "." + this.cfDomain;


### PR DESCRIPTION
Instead of specifying UAA URL as a combination of UAA_HOST:UAA_PORT, use
UAA_ROUTE, which is also exported by the test running script. This
simplifies things, and lets the test script pick the route if specified
in the environment. This is useful for local minikube runs, which like
local runs is tested over HTTP, but where the UAA URL does not have a
port specified, and no CF steps are needed to be executed (see
uaa-cf-release PR [1])

[1] https://github.build.ge.com/predix/uaa-cf-release/pull/58