### PR TITLE
Set version to 75.18.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=75.18.0
+version=75.18.1
 
 # Required for LdapMockMvcTests when asserting it can find a user in a different language
 org.gradle.jvmargs=-Dfile.encoding=utf8 -XX:+StartAttachListener -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/uaa-tests.hprof


### PR DESCRIPTION
This is the version that contains changes for deployment to Kubernetes.
Docker images pushed by the DockerizeJenkinsfile job use this version
for tagging images [1]. So this commit makes sure that images built are
tagged with the new version.

[1] https://github.com/GESoftware-CF/uaa/blob/predix_extensions_75.18.1/DockerizeJenkinsfile#L125