### PR TITLE
Update rc & release branches selector regex for GE SOS Build pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -447,9 +447,9 @@ pipeline {
 
             // Trigger GE SOS build job for uaa image build
             script {
-                if (params.TRIGGER_GESOS_IMAGE_BUILD && (BRANCH_NAME.matches('rc_*') || BRANCH_NAME.matches('release_*'))) {
+                if (params.TRIGGER_GESOS_IMAGE_BUILD && (BRANCH_NAME.matches('rc_[\\d.]+') || BRANCH_NAME.matches('release_[\\d.]+'))) {
                     imageTag = BRANCH_NAME
-                    if (imageTag.matches('release_*')) {
+                    if (imageTag.matches('release_[\\d.]+')) {
                         imageTag = imageTag.replaceAll('release_', '')
                     }
             	    build job: JOB_NAME.replaceAll('/Build n Test/', '/GE SOS Build/'),


### PR DESCRIPTION
Currently UAA branches starting with rc_ and release_ publishes
UAA artifact jar to artifactory server so trigger GE SOS
build for these branches only.

Regex is used to compare & match branch name and trigger
GE SOS build pipeline for rc and release branches. The
old regex was incorrect and was not triggering ge sos build
for eligible branches so corrected regex to trigger ge sos
build for rc and release branches.