### PR TITLE
Fix password reset email failure due to javax.mail conflict

### DIFF
--- a/uaa/build.gradle
+++ b/uaa/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     providedCompile(libraries.tomcatEmbed)
 
     implementation(libraries.springMeteringFilter) {
-        exclude(module: "javax.mail")
+        exclude(group: "javax.mail")
     }
     //implementation(libraries.dynamicLogConfigurer)
     runtimeOnly(libraries.nurego)


### PR DESCRIPTION
Fix password reset email failure due to javax.mail conflict
spring-metering-filter dependency [1] pulls in `javax.mail:mailapi`
which conflicts with `com.sun.mail:jakarta.mail` pulled in by UAA [2][3]
for sending emails.  If the `mailapi` library gets used rather than
`jakarta.mail` (seems to depend on JAR loading order and so the problem
is intermittent), the following error gets thrown when a password reset
email is tried to be sent:

    java.lang.NoSuchMethodError: 'void com.sun.mail.util.TraceInputStream.<init>(java.io.InputStream, com.sun.mail.util.MailLogger)

- Fix by fixing the exclusion of `javax.mail` in the dependency
  specification for spring-metering-filter in build.gradle by specifying
  it as the group rather than the module

It is possible to explicitly exclude only the mailapi module from
spring-metering-filter, but javax.mail:mailapi is usually used with
javax.mail:mail which implements the API. So its best to exclude all the
modules in the group, rather than just the mailapi module. That actually
was how it was in the beginning. See commit https://github.com/GESoftware-CF/uaa/commit/aff34e28ac9fe927e1dc18267d7649d4735e2096. But that got tweaked
incorrectly in commit https://github.com/GESoftware-CF/uaa/commit/11777bb7911a29c89971aa4ef9bc52e778983752, which changed the group to be the module,
probably because sadly, there is a module called javax.mail also within
a com.sun.mail group [4]. But in this case, javax.mail:mailapi is what
gets pulled in by spring-metering-filter, and so the exclusion of the
group javax.mail works. Without the exclusion, mailapi JAR is found in
the application WAR file, along with jakarta.mail JAR with which it
conflicts. With this change, only jakarta.mail JAR exists in the WAR,
and the reset email functionality works.

[1] https://github.com/GESoftware-CF/uaa/blob/release_75.18.0/dependencies.gradle#L125
[2] https://github.com/GESoftware-CF/uaa/blob/release_75.18.0/dependencies.gradle#L50
[3] https://github.com/GESoftware-CF/uaa/blob/release_75.18.0/server/build.gradle#L16
[4] https://mvnrepository.com/search?q=javax.mail