### PR TITLE
Split "self-service" flag in UAA zone config to independently

### DIFF
--- a/model/src/main/java/org/cloudfoundry/identity/uaa/zone/Links.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/zone/Links.java
@@ -16,6 +16,7 @@ package org.cloudfoundry.identity.uaa.zone;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import org.springframework.util.StringUtils;
 
 import java.util.List;
 import java.util.Optional;
@@ -99,6 +100,8 @@ public class Links {
 
     public static class SelfService {
         private boolean selfServiceLinksEnabled = true;
+        private boolean selfServiceCreateAccountEnabled = true;
+        private boolean selfServiceResetPasswordEnabled = true;
         private String signup = null;
         private String passwd = null;
 
@@ -108,6 +111,30 @@ public class Links {
 
         public SelfService setSelfServiceLinksEnabled(boolean selfServiceLinksEnabled) {
             this.selfServiceLinksEnabled = selfServiceLinksEnabled;
+            if (!selfServiceLinksEnabled) {
+                this.selfServiceCreateAccountEnabled = false;
+                this.selfServiceResetPasswordEnabled = false;
+            }
+            return this;
+        }
+        public SelfService setSelfServiceCreateAccountEnabled(boolean selfServiceCreateAccountEnabled) {
+            if (selfServiceCreateAccountEnabled && !StringUtils.hasText(this.signup)){
+                this.signup = "/create_account";
+            }
+            this.selfServiceCreateAccountEnabled = selfServiceCreateAccountEnabled;
+            return this;
+        }
+
+        public boolean isSelfServiceCreateAccountEnabled() {
+            return selfServiceCreateAccountEnabled;
+        }
+
+        public boolean isSelfServiceResetPasswordEnabled() {
+            return selfServiceResetPasswordEnabled;
+        }
+
+        public SelfService setSelfServiceResetPasswordEnabled(boolean selfServiceResetPasswordEnabled) {
+            this.selfServiceResetPasswordEnabled = selfServiceResetPasswordEnabled;
             return this;
         }
 
@@ -126,8 +153,10 @@ public class Links {
 
         public SelfService setSignup(String signup) {
             this.signup = signup;
+            if (!StringUtils.hasText(signup)) {
+                this.selfServiceCreateAccountEnabled = false;
+            }
             return this;
         }
     }
-
 }

--- a/model/src/test/resources/org/cloudfoundry/identity/uaa/zone/SampleIdentityZone.json
+++ b/model/src/test/resources/org/cloudfoundry/identity/uaa/zone/SampleIdentityZone.json
@@ -82,7 +82,8 @@
         "whitelist": null
       },
       "selfService": {
-        "selfServiceLinksEnabled": true,
+        "selfServiceResetPasswordEnabled": true,
+        "selfServiceCreateAccountEnabled": true,
         "signup": null,
         "passwd": null
       }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/account/AccountsController.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/account/AccountsController.java
@@ -46,8 +46,10 @@ public class AccountsController {
                                   @RequestParam(value = "client_id", required = false) String clientId,
                                   @RequestParam(value = "redirect_uri", required = false) String redirectUri,
                                   HttpServletResponse response) {
-        if (!IdentityZoneHolder.get().getConfig().getLinks().getSelfService().isSelfServiceLinksEnabled()) {
-            return handleSelfServiceDisabled(model, response, "error_message_code", "self_service_disabled");
+        boolean isSelfServiceCreateAccountEnabled = IdentityZoneHolder.get().getConfig().getLinks().getSelfService().isSelfServiceCreateAccountEnabled();
+        if (!isSelfServiceCreateAccountEnabled) {
+            return handleSelfServiceDisabled(model, response, "error_message_code",
+                                             "self_service_create_account_disabled");
         }
         model.addAttribute("client_id", clientId);
         model.addAttribute("redirect_uri", redirectUri);
@@ -69,8 +71,10 @@ public class AccountsController {
         if (zoneBranding != null && zoneBranding.getConsent() != null && !doesUserConsent) {
             return handleUnprocessableEntity(model, response, "error_message_code", "missing_consent");
         }
-        if (!IdentityZoneHolder.get().getConfig().getLinks().getSelfService().isSelfServiceLinksEnabled()) {
-            return handleSelfServiceDisabled(model, response, "error_message_code", "self_service_disabled");
+        boolean isSelfServiceCreateAccountEnabled = IdentityZoneHolder.get().getConfig().getLinks().getSelfService().isSelfServiceCreateAccountEnabled();
+        if (!isSelfServiceCreateAccountEnabled) {
+            return handleSelfServiceDisabled(model, response, "error_message_code",
+                                             "self_service_create_account_disabled");
         }
         if (result.hasErrors()) {
             return handleUnprocessableEntity(model, response, "error_message_code", "invalid_email");

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/account/ResetPasswordController.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/account/ResetPasswordController.java
@@ -64,8 +64,10 @@ public class ResetPasswordController {
                                      @RequestParam(required = false, value = "client_id") String clientId,
                                      @RequestParam(required = false, value = "redirect_uri") String redirectUri,
                                      HttpServletResponse response) {
-        if (!IdentityZoneHolder.get().getConfig().getLinks().getSelfService().isSelfServiceLinksEnabled()) {
-            return handleSelfServiceDisabled(model, response, "error_message_code", "self_service_disabled");
+        boolean isSelfServiceResetPasswordEnabled = IdentityZoneHolder.get().getConfig().getLinks().getSelfService().isSelfServiceResetPasswordEnabled();
+        if (!isSelfServiceResetPasswordEnabled) {
+            return handleSelfServiceDisabled(model, response, "error_message_code",
+                                             "self_service_reset_password_disabled");
         }
         model.addAttribute("client_id", clientId);
         model.addAttribute("redirect_uri", redirectUri);
@@ -75,8 +77,10 @@ public class ResetPasswordController {
     @RequestMapping(value = "/forgot_password.do", method = RequestMethod.POST)
     public String forgotPassword(Model model, @RequestParam("username") String username, @RequestParam(value = "client_id", defaultValue = "") String clientId,
                                  @RequestParam(value = "redirect_uri", defaultValue = "") String redirectUri, HttpServletResponse response) {
-        if (!IdentityZoneHolder.get().getConfig().getLinks().getSelfService().isSelfServiceLinksEnabled()) {
-            return handleSelfServiceDisabled(model, response, "error_message_code", "self_service_disabled");
+        boolean isSelfServiceResetPasswordEnabled = IdentityZoneHolder.get().getConfig().getLinks().getSelfService().isSelfServiceResetPasswordEnabled();
+        if (!isSelfServiceResetPasswordEnabled) {
+            return handleSelfServiceDisabled(model, response, "error_message_code",
+                                             "self_service_reset_password_disabled");
         }
         forgotPassword(username, clientId, redirectUri);
         return "redirect:email_sent?code=reset_password";

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/IdentityZoneConfigurationBootstrap.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/IdentityZoneConfigurationBootstrap.java
@@ -41,7 +41,8 @@ public class IdentityZoneConfigurationBootstrap implements InitializingBean {
     private ClientSecretPolicy clientSecretPolicy;
     private TokenPolicy tokenPolicy;
     private IdentityZoneProvisioning provisioning;
-    private boolean selfServiceLinksEnabled = true;
+    private boolean selfServiceCreateAccountEnabled = true;
+    private boolean selfServiceResetPasswordEnabled = true;
     private String homeRedirect = null;
     private Map<String,Object> selfServiceLinks;
     private boolean mfaEnabled;
@@ -84,7 +85,8 @@ public class IdentityZoneConfigurationBootstrap implements InitializingBean {
         IdentityZone identityZone = provisioning.retrieve(IdentityZone.getUaaZoneId());
         IdentityZoneConfiguration definition = new IdentityZoneConfiguration(tokenPolicy);
         definition.setClientSecretPolicy(clientSecretPolicy);
-        definition.getLinks().getSelfService().setSelfServiceLinksEnabled(selfServiceLinksEnabled);
+        definition.getLinks().getSelfService().setSelfServiceCreateAccountEnabled(selfServiceCreateAccountEnabled);
+        definition.getLinks().getSelfService().setSelfServiceResetPasswordEnabled(selfServiceResetPasswordEnabled);
         definition.getLinks().setHomeRedirect(homeRedirect);
         definition.getSamlConfig().setCertificate(samlSpCertificate);
         definition.getSamlConfig().setPrivateKey(samlSpPrivateKey);
@@ -176,8 +178,12 @@ public class IdentityZoneConfigurationBootstrap implements InitializingBean {
         this.tokenPolicy = tokenPolicy;
     }
 
-    public void setSelfServiceLinksEnabled(boolean selfServiceLinksEnabled) {
-        this.selfServiceLinksEnabled = selfServiceLinksEnabled;
+    public void setSelfServiceCreateAccountEnabled(boolean selfServiceCreateAccountEnabled) {
+        this.selfServiceCreateAccountEnabled = selfServiceCreateAccountEnabled;
+    }
+
+    public void setSelfServiceResetPasswordEnabled(boolean selfServiceResetPasswordEnabled) {
+        this.selfServiceResetPasswordEnabled = selfServiceResetPasswordEnabled;
     }
 
     public void setHomeRedirect(String homeRedirect) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
@@ -973,8 +973,10 @@ public class LoginInfoEndpoint {
         IdentityProvider<UaaIdentityProviderDefinition> uaaIdp = providerProvisioning.retrieveByOriginIgnoreActiveFlag(OriginKeys.UAA, IdentityZoneHolder.get().getId());
         boolean disableInternalUserManagement = (uaaIdp.getConfig() != null) ? uaaIdp.getConfig().isDisableInternalUserManagement() : false;
 
-        boolean selfServiceLinksEnabled = (zone.getConfig() != null) ? zone.getConfig().getLinks().getSelfService().isSelfServiceLinksEnabled() : true;
-
+        boolean selfServiceResetPasswordEnabled = (zone.getConfig() != null) ? zone.getConfig().getLinks().getSelfService()
+                                                                                   .isSelfServiceResetPasswordEnabled() : true;
+        boolean selfServiceCreateAccountEnabled = (zone.getConfig() != null) ? zone.getConfig().getLinks().getSelfService()
+                                                                                   .isSelfServiceCreateAccountEnabled() : true;
         final String defaultSignup = "";
         final String defaultPasswd = "/forgot_password";
         Links.SelfService service = zone.getConfig() != null ? zone.getConfig().getLinks().getSelfService() : null;
@@ -988,16 +990,18 @@ public class LoginInfoEndpoint {
                 globalLinks.getSelfService().getPasswd(),
                 defaultPasswd);
 
-        if (selfServiceLinksEnabled && !disableInternalUserManagement) {
-            if (hasText(signup)) {
-                signup = UaaStringUtils.replaceZoneVariables(signup, IdentityZoneHolder.get());
-                selfServiceLinks.put(CREATE_ACCOUNT_LINK, signup);
-                selfServiceLinks.put("register", signup);
-            }
+        if (selfServiceResetPasswordEnabled && !disableInternalUserManagement) {
             if (hasText(passwd)) {
                 passwd = UaaStringUtils.replaceZoneVariables(passwd, IdentityZoneHolder.get());
                 selfServiceLinks.put(FORGOT_PASSWORD_LINK, passwd);
                 selfServiceLinks.put("passwd", passwd);
+            }
+        }
+        if (selfServiceCreateAccountEnabled && !disableInternalUserManagement) {
+            if (hasText(signup)) {
+                signup = UaaStringUtils.replaceZoneVariables(signup, IdentityZoneHolder.get());
+                selfServiceLinks.put(CREATE_ACCOUNT_LINK, signup);
+                selfServiceLinks.put("register", signup);
             }
         }
         return selfServiceLinks;

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/config/IdentityZoneConfigurationBootstrapTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/config/IdentityZoneConfigurationBootstrapTests.java
@@ -198,12 +198,21 @@ public class IdentityZoneConfigurationBootstrapTests {
     }
 
     @Test
-    public void disable_self_service_links() throws Exception {
-        bootstrap.setSelfServiceLinksEnabled(false);
+    public void disable_self_service_create_account_links() throws Exception {
+        bootstrap.setSelfServiceCreateAccountEnabled(false);
         bootstrap.afterPropertiesSet();
 
         IdentityZone zone = provisioning.retrieve(IdentityZone.getUaaZoneId());
-        assertFalse(zone.getConfig().getLinks().getSelfService().isSelfServiceLinksEnabled());
+        assertFalse(zone.getConfig().getLinks().getSelfService().isSelfServiceCreateAccountEnabled());
+    }
+
+    @Test
+    public void disable_self_service_reset_password_links() throws Exception {
+        bootstrap.setSelfServiceResetPasswordEnabled(false);
+        bootstrap.afterPropertiesSet();
+
+        IdentityZone zone = provisioning.retrieve(IdentityZone.getUaaZoneId());
+        assertFalse(zone.getConfig().getLinks().getSelfService().isSelfServiceResetPasswordEnabled());
     }
 
     @Test
@@ -230,6 +239,7 @@ public class IdentityZoneConfigurationBootstrapTests {
     public void passwd_link_configured() throws Exception {
         links.put("passwd", "/configured_passwd");
         bootstrap.setSelfServiceLinks(links);
+        bootstrap.setSelfServiceCreateAccountEnabled(false);
         bootstrap.afterPropertiesSet();
 
         IdentityZone zone = provisioning.retrieve(IdentityZone.getUaaZoneId());

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpointTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpointTests.java
@@ -393,6 +393,7 @@ class LoginInfoEndpointTests {
         validateSelfServiceLinks(null, "http://custom_passwd_link", endpoint.getSelfServiceLinks());
 
         IdentityZoneHolder.get().getConfig().getLinks().getSelfService().setSignup("http://custom_signup_link");
+        IdentityZoneHolder.get().getConfig().getLinks().getSelfService().setSelfServiceCreateAccountEnabled(true);
         IdentityZoneHolder.get().getConfig().getLinks().getSelfService().setPasswd("");
         endpoint.loginForHtml(extendedModelMap, null, new MockHttpServletRequest(), null);
         validateSelfServiceLinks("http://custom_signup_link", null, extendedModelMap);
@@ -568,7 +569,8 @@ class LoginInfoEndpointTests {
     void no_self_service_links_if_self_service_disabled() {
         IdentityZone zone = MultitenancyFixture.identityZone("zone", "zone");
         zone.setConfig(new IdentityZoneConfiguration());
-        zone.getConfig().getLinks().getSelfService().setSelfServiceLinksEnabled(false);
+        zone.getConfig().getLinks().getSelfService().setSelfServiceCreateAccountEnabled(false);
+        zone.getConfig().getLinks().getSelfService().setSelfServiceResetPasswordEnabled(false);
         IdentityZoneHolder.set(zone);
         LoginInfoEndpoint endpoint = getEndpoint(zone);
         endpoint.infoForJson(extendedModelMap, null, new MockHttpServletRequest("GET", "http://someurl"));

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/login/ResetPasswordControllerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/login/ResetPasswordControllerTest.java
@@ -106,7 +106,7 @@ class ResetPasswordControllerTest extends TestClassNullifier {
     @Test
     void testForgotPasswordWithSelfServiceDisabled() throws Exception {
         IdentityZone zone = MultitenancyFixture.identityZone("test-zone-id", "testsubdomain");
-        zone.getConfig().getLinks().getSelfService().setSelfServiceLinksEnabled(false);
+        zone.getConfig().getLinks().getSelfService().setSelfServiceResetPasswordEnabled(false);
         IdentityZoneHolder.set(zone);
 
         mockMvc.perform(get("/forgot_password")
@@ -114,7 +114,7 @@ class ResetPasswordControllerTest extends TestClassNullifier {
                 .param("redirect_uri", "http://example.com"))
                 .andExpect(status().isNotFound())
                 .andExpect(view().name("error"))
-                .andExpect(model().attribute("error_message_code", "self_service_disabled"));
+                .andExpect(model().attribute("error_message_code", "self_service_reset_password_disabled"));
     }
 
     @Test
@@ -209,7 +209,7 @@ class ResetPasswordControllerTest extends TestClassNullifier {
     @Test
     void forgotPasswordPostWithSelfServiceDisabled() throws Exception {
         IdentityZone zone = MultitenancyFixture.identityZone("test-zone-id", "testsubdomain");
-        zone.getConfig().getLinks().getSelfService().setSelfServiceLinksEnabled(false);
+        zone.getConfig().getLinks().getSelfService().setSelfServiceResetPasswordEnabled(false);
         IdentityZoneHolder.set(zone);
 
         mockMvc.perform(post("/forgot_password.do")
@@ -219,7 +219,7 @@ class ResetPasswordControllerTest extends TestClassNullifier {
                 .param("redirect_uri", "redirect.example.com"))
                 .andExpect(status().isNotFound())
                 .andExpect(view().name("error"))
-                .andExpect(model().attribute("error_message_code", "self_service_disabled"));
+                .andExpect(model().attribute("error_message_code", "self_service_reset_password_disabled"));
     }
 
     private void forgotPasswordSuccessful(String url) throws Exception {

--- a/uaa/src/main/resources/messages.properties
+++ b/uaa/src/main/resources/messages.properties
@@ -66,7 +66,8 @@ NotNull.identityZone.subdomain=The subdomain must be provided.
 NotNull.identityZone.name=The identity zone must be given a name.
 
 zone.not.found=The subdomain does not map to a valid identity zone.
-self_service_disabled=Self service is disabled.
+self_service_create_account_disabled=Self service create account is disabled.
+self_service_reset_password_disabled=Self service reset password is disabled.
 
 error.sso.supported.binding=No Supported binding was found for SAML SSO profile - browser. Supported SAML SSO browser profile bindings are HTTP-POST and HTTP-Redirect.
 

--- a/uaa/src/main/webapp/WEB-INF/spring-servlet.xml
+++ b/uaa/src/main/webapp/WEB-INF/spring-servlet.xml
@@ -467,7 +467,8 @@
         <property name="validator" ref="identityZoneValidator"/>
         <property name="clientSecretPolicy" ref="defaultUaaClientSecretPolicy"/>
         <property name="tokenPolicy" ref="uaaTokenPolicy"/>
-        <property name="selfServiceLinksEnabled" value="${login.selfServiceLinksEnabled:true}"/>
+        <property name="selfServiceResetPasswordEnabled" value="${login.selfServiceResetPasswordEnabled:true}"/>
+        <property name="selfServiceCreateAccountEnabled" value="${login.selfServiceCreateAccountEnabled:true}"/>
         <property name="selfServiceLinks" ref="links"/>
         <property name="homeRedirect" value="${links.homeRedirect:${login.homeRedirect:#{null}}}"/>
         <property name="idpDiscoveryEnabled" value="${login.idpDiscoveryEnabled:false}"/>

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/LoginIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/LoginIT.java
@@ -489,6 +489,7 @@ public class LoginIT {
         IdentityZoneConfiguration config = new IdentityZoneConfiguration();
         config.setIdpDiscoveryEnabled(true);
         config.setAccountChooserEnabled(true);
+        config.getLinks().setSelfService(new Links.SelfService().setSignup("/create_account").setPasswd(""));
         IntegrationTestUtils.createZoneOrUpdateSubdomain(identityClient, baseUrl, testzone3, testzone3, config);
         IdentityProvider provider = new IdentityProvider();
         provider.setIdentityZoneId(testzone3);
@@ -531,33 +532,62 @@ public class LoginIT {
     }
 
     @Test
-    public void testSelfServiceLinksBehavior() {
+    public void testSelfServiceResetPasswordLinksBehavior() {
         RestTemplate adminClient = IntegrationTestUtils.getClientCredentialsTemplate(
                 IntegrationTestUtils.getClientCredentialsResource(baseUrl, new String[0], "admin", "adminsecret"));
         String zoneId = "testzone3";
         String zoneUrl = baseUrl.replace("localhost", zoneId+".localhost");
+        Links.SelfService selfService = new Links.SelfService();
         IdentityZone testZone3 = IntegrationTestUtils.createZoneOrUpdateSubdomain(adminClient, baseUrl, zoneId, zoneId, new IdentityZoneConfiguration());
 
-        testZone3.getConfig().getLinks().setSelfService(new Links.SelfService().setSelfServiceLinksEnabled(true).setPasswd("").setSignup(""));
+        testZone3.getConfig().getLinks().setSelfService(selfService.setSelfServiceResetPasswordEnabled(true).setPasswd(""));
+        IntegrationTestUtils.createZoneOrUpdateSubdomain(adminClient, baseUrl, zoneId, zoneId, testZone3.getConfig());
+        webDriver.get(zoneUrl);
+        assertEquals(0, webDriver.findElements(By.xpath("//*[text()='Reset password']")).size());
+
+        testZone3.getConfig().getLinks().setSelfService(selfService.setSelfServiceResetPasswordEnabled(true).setPasswd(null));
+        IntegrationTestUtils.createZoneOrUpdateSubdomain(adminClient, baseUrl, zoneId, zoneId, testZone3.getConfig());
+        webDriver.get(zoneUrl);
+        assertEquals(1, webDriver.findElements(By.xpath("//*[text()='Reset password']")).size());
+
+        testZone3.getConfig().getLinks().setSelfService(selfService.setSelfServiceResetPasswordEnabled(true).setPasswd("/forgot_password"));
+        IntegrationTestUtils.createZoneOrUpdateSubdomain(adminClient, baseUrl, zoneId, zoneId, testZone3.getConfig());
+        webDriver.get(zoneUrl);
+        assertEquals(1, webDriver.findElements(By.xpath("//*[text()='Reset password']")).size());
+
+        testZone3.getConfig().getLinks().setSelfService(selfService.setSelfServiceResetPasswordEnabled(false).setPasswd("/forgot_password"));
+        IntegrationTestUtils.createZoneOrUpdateSubdomain(adminClient, baseUrl, zoneId, zoneId, testZone3.getConfig());
+        webDriver.get(zoneUrl);
+        assertEquals(0, webDriver.findElements(By.xpath("//*[text()='Reset password']")).size());
+    }
+
+    @Test
+    public void testSelfServiceCreateAccountLinksBehavior() {
+        RestTemplate adminClient = IntegrationTestUtils.getClientCredentialsTemplate(
+            IntegrationTestUtils.getClientCredentialsResource(baseUrl, new String[0], "admin", "adminsecret"));
+        String zoneId = "testzone3";
+        String zoneUrl = baseUrl.replace("localhost", zoneId+".localhost");
+        Links.SelfService selfService = new Links.SelfService();
+        IdentityZone testZone3 = IntegrationTestUtils.createZoneOrUpdateSubdomain(adminClient, baseUrl, zoneId, zoneId, new IdentityZoneConfiguration());
+
+        testZone3.getConfig().getLinks().setSelfService(selfService.setSelfServiceCreateAccountEnabled(true).setSignup(""));
         IntegrationTestUtils.createZoneOrUpdateSubdomain(adminClient, baseUrl, zoneId, zoneId, testZone3.getConfig());
         webDriver.get(zoneUrl);
         assertEquals(0, webDriver.findElements(By.xpath("//*[text()='Create account']")).size());
-        assertEquals(0, webDriver.findElements(By.xpath("//*[text()='Reset password']")).size());
 
-        testZone3.getConfig().getLinks().setSelfService(new Links.SelfService().setSelfServiceLinksEnabled(true).setPasswd("/forgot_password").setSignup("http://example.com"));
+        testZone3.getConfig().getLinks().setSelfService(selfService.setSelfServiceCreateAccountEnabled(true).setSignup(null));
+        IntegrationTestUtils.createZoneOrUpdateSubdomain(adminClient, baseUrl, zoneId, zoneId, testZone3.getConfig());
+        webDriver.get(zoneUrl);
+        assertEquals(0, webDriver.findElements(By.xpath("//*[text()='Create account']")).size());
+
+        testZone3.getConfig().getLinks().setSelfService(selfService.setSelfServiceCreateAccountEnabled(false).setSignup("/create_account"));
+        IntegrationTestUtils.createZoneOrUpdateSubdomain(adminClient, baseUrl, zoneId, zoneId, testZone3.getConfig());
+        webDriver.get(zoneUrl);
+        assertEquals(0, webDriver.findElements(By.xpath("//*[text()='Create account']")).size());
+
+        testZone3.getConfig().getLinks().setSelfService(selfService.setSelfServiceCreateAccountEnabled(true).setSignup("/create_account"));
         IntegrationTestUtils.createZoneOrUpdateSubdomain(adminClient, baseUrl, zoneId, zoneId, testZone3.getConfig());
         webDriver.get(zoneUrl);
         assertEquals(1, webDriver.findElements(By.xpath("//*[text()='Create account']")).size());
-        assertEquals(1, webDriver.findElements(By.xpath("//*[text()='Reset password']")).size());
-
-        testZone3.getConfig().getLinks().setSelfService(new Links.SelfService().setSelfServiceLinksEnabled(true).setPasswd(null).setSignup(null));
-        IntegrationTestUtils.createZoneOrUpdateSubdomain(adminClient, baseUrl, zoneId, zoneId, testZone3.getConfig());
-        webDriver.get(zoneUrl);
-        assertEquals(0, webDriver.findElements(By.xpath("//*[text()='Create account']")).size());
-        assertEquals(1, webDriver.findElements(By.xpath("//*[text()='Reset password']")).size());
-
-        testZone3.getConfig().getLinks().setSelfService(new Links.SelfService().setSelfServiceLinksEnabled(true).setPasswd("/forgot_password").setSignup("/create_account"));
-        IntegrationTestUtils.createZoneOrUpdateSubdomain(adminClient, baseUrl, zoneId, zoneId, testZone3.getConfig());
-
     }
 }

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/util/MockMvcUtils.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/util/MockMvcUtils.java
@@ -478,9 +478,15 @@ public final class MockMvcUtils {
         provisioning.update(uaaIdp, zoneId);
     }
 
-    public static void setSelfServiceLinksEnabled(ApplicationContext context, String zoneId, boolean enabled) {
+    public static void setSelfServiceCreateAccountEnabled(ApplicationContext context, String zoneId, boolean enabled) {
         IdentityZoneConfiguration config = getZoneConfiguration(context, zoneId);
-        config.getLinks().getSelfService().setSelfServiceLinksEnabled(enabled);
+        config.getLinks().getSelfService().setSelfServiceCreateAccountEnabled(enabled);
+        setZoneConfiguration(context, zoneId, config);
+    }
+
+    public static void setSelfServiceResetPasswordEnabled(ApplicationContext context, String zoneId, boolean enabled) {
+        IdentityZoneConfiguration config = getZoneConfiguration(context, zoneId);
+        config.getLinks().getSelfService().setSelfServiceResetPasswordEnabled(enabled);
         setZoneConfiguration(context, zoneId, config);
     }
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/zones/IdentityZoneEndpointsMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/zones/IdentityZoneEndpointsMockMvcTests.java
@@ -679,6 +679,7 @@ class IdentityZoneEndpointsMockMvcTests {
         created.setDescription("updated description");
         IdentityZoneConfiguration definition = new IdentityZoneConfiguration(new TokenPolicy(3600, 7200));
         definition.getSamlConfig().setSignatureAlgorithm(globalDefaultSamlSignatureAlgorithm);
+        definition.getLinks().getSelfService().setSelfServiceCreateAccountEnabled(false);
         created.setConfig(definition);
 
         IdentityZone updated = updateZone(created, HttpStatus.OK, identityClientToken);
@@ -982,6 +983,7 @@ class IdentityZoneEndpointsMockMvcTests {
 
         IdentityZoneConfiguration definition = new IdentityZoneConfiguration(tokenPolicy);
         identityZone.setConfig(definition.setSamlConfig(samlConfig));
+        definition.getLinks().getSelfService().setSelfServiceCreateAccountEnabled(false);
 
         mockMvc.perform(
                 post(url)

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/performance/LoginPagePerformanceMockMvcTest.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/performance/LoginPagePerformanceMockMvcTest.java
@@ -84,7 +84,8 @@ public class LoginPagePerformanceMockMvcTest {
 
     @AfterEach
     void tearDown(@Autowired IdentityZoneConfigurationBootstrap identityZoneConfigurationBootstrap) throws Exception {
-        MockMvcUtils.setSelfServiceLinksEnabled(webApplicationContext, IdentityZone.getUaaZoneId(), true);
+        MockMvcUtils.setSelfServiceCreateAccountEnabled(webApplicationContext, IdentityZone.getUaaZoneId(), true);
+        MockMvcUtils.setSelfServiceResetPasswordEnabled(webApplicationContext, IdentityZone.getUaaZoneId(), true);
         identityZoneConfigurationBootstrap.afterPropertiesSet();
         SecurityContextHolder.clearContext();
         IdentityZoneHolder.clear();

--- a/uaa/src/test/resources/integration_test_properties.yml
+++ b/uaa/src/test/resources/integration_test_properties.yml
@@ -61,7 +61,8 @@ login:
     KdcZYgl4l/L6PxJ982SRhc83ZW2dkAZI4M0/Ud3oePe84k8jm3A7EvH5wi5hvCkK
     RpuRBwn3Ei+jCRouxTbzKPsuCVB+1sNyxMTXzf0=
     -----END CERTIFICATE-----
-  selfServiceLinksEnabled: true
+  selfServiceResetPasswordEnabled: true
+  selfServiceCreateAccountEnabled: true
   url: http://localhost:8080/uaa
   entityBaseURL: http://localhost:8080/uaa
   entityID: cloudfoundry-saml-login


### PR DESCRIPTION
toggle "Reset Password" and "Register User" functionality
Apply split "self-service" flag to existing UAA zone configs
- If "Reset Password" flag is enabled, user can see the
 "Reset Password" link, and navigate to "Reset Password" screen.
 If "Reset Password" flag is disabled, "Reset Password" link
 is not visible.Navigate to "Reset Password" ("/forgot_password")
 screen gives error screen with messsage "Self service reset
 password is disabled." and rest api will return 404 http status.
- The same is applicable for ""Register User" (“/create_account”)
 flag."