### PR TITLE
Set default values as "/forgot_password" in Links

### DIFF
--- a/model/src/main/java/org/cloudfoundry/identity/uaa/zone/Links.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/zone/Links.java
@@ -134,6 +134,9 @@ public class Links {
         }
 
         public SelfService setSelfServiceResetPasswordEnabled(boolean selfServiceResetPasswordEnabled) {
+            if (selfServiceResetPasswordEnabled && !StringUtils.hasText(this.passwd)){
+                this.passwd = "/forgot_password";
+            }
             this.selfServiceResetPasswordEnabled = selfServiceResetPasswordEnabled;
             return this;
         }

--- a/model/src/main/java/org/cloudfoundry/identity/uaa/zone/Links.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/zone/Links.java
@@ -105,18 +105,14 @@ public class Links {
         private String signup = null;
         private String passwd = null;
 
-        public boolean isSelfServiceLinksEnabled() {
-            return selfServiceLinksEnabled;
-        }
-
-        public SelfService setSelfServiceLinksEnabled(boolean selfServiceLinksEnabled) {
+        public void setSelfServiceLinksEnabled(boolean selfServiceLinksEnabled) {
             this.selfServiceLinksEnabled = selfServiceLinksEnabled;
             if (!selfServiceLinksEnabled) {
                 this.selfServiceCreateAccountEnabled = false;
                 this.selfServiceResetPasswordEnabled = false;
             }
-            return this;
         }
+
         public SelfService setSelfServiceCreateAccountEnabled(boolean selfServiceCreateAccountEnabled) {
             if (selfServiceCreateAccountEnabled && !StringUtils.hasText(this.signup)){
                 this.signup = "/create_account";

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/config/IdentityZoneConfigurationBootstrapTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/config/IdentityZoneConfigurationBootstrapTests.java
@@ -232,7 +232,7 @@ public class IdentityZoneConfigurationBootstrapTests {
 
         IdentityZone zone = provisioning.retrieve(IdentityZone.getUaaZoneId());
         assertEquals("/configured_signup", zone.getConfig().getLinks().getSelfService().getSignup());
-        assertNull(zone.getConfig().getLinks().getSelfService().getPasswd());
+        assertEquals("/forgot_password", zone.getConfig().getLinks().getSelfService().getPasswd());
     }
 
     @Test


### PR DESCRIPTION
For "create account" and "reset password" links
-Default values are set in Links model.
-Any values set in model will be reflected back to the caller.
-As per  LoginInfoEndpoint.java#L980-L991 priority of picking up
 link value for both links(/create_account, /forgot_password) is
 zone settings then global settings then default.