### PR TITLE
Fix JwtBearerGrantAT for all environments

### DIFF
--- a/uaa/build.gradle
+++ b/uaa/build.gradle
@@ -158,6 +158,12 @@ integrationTest {
     }
 }
 
+task acceptanceTest(type: Test) {
+  // Don't let tests be 'UP-TO-DATE' and not run
+  outputs.upToDateWhen { false }
+  include "org/cloudfoundry/identity/uaa/acceptance/*.class"
+}
+
 
 task degradedJwtTestCloud(type: Test) {
     systemProperty "RUN_AGAINST_CLOUD", true

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/acceptance/JwtBearerGrantAT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/acceptance/JwtBearerGrantAT.java
@@ -54,26 +54,11 @@ public class JwtBearerGrantAT {
 
     protected final static Logger logger = LoggerFactory.getLogger(JwtBearerGrantAT.class);
 
-    @Value("${PUBLISHED_HOST:predix-uaa-integration}")
-    String publishedHost;
-
-    @Value("${CF_DOMAIN:run.aws-usw02-dev.ice.predix.io}")
-    String cfDomain;
-
-    @Value("${ACCEPTANCE_SUBDOMAIN:uaa-acceptance-zone}")
-    String zoneSubdomain;
-
-    @Value("${RUN_AGAINST_LOCAL_UAA:false}")
-    boolean runAgainstLocalUaa;
+    @Value("${ACCEPTANCE_ZONE_URL:}")
+    String acceptanceZoneUrl;
 
     @Value("${KEY_PROVIDER_SERVICE_URL:not-used}")
     String keyProviderServiceUrl;
-
-    @Value("${UAA_ROUTE:}")
-    String uaaRoute;
-
-    @Value("${UAA_PATH:}")
-    String uaaPath;
 
     @Value("${TOKEN_ISSUER_URL:}")
     String tokenIssuerUrl;
@@ -81,8 +66,6 @@ public class JwtBearerGrantAT {
     private OAuth2RestTemplate adminClientRestTemplate;
     private BaseClientDetails identityClient;
     private final RestTemplate tokenRestTemplate = new RestTemplate();
-
-    String acceptanceZoneUrl;
     String assertionTokenAudience;
     String acceptanceTokenIssuer;
 
@@ -90,14 +73,9 @@ public class JwtBearerGrantAT {
     public void beforeEachTest() throws Exception {
         Assume.assumeTrue(keyProviderServiceUrl != null &&
                 keyProviderServiceUrl.trim().startsWith("http"));
+        Assume.assumeTrue(acceptanceZoneUrl != null &&
+                acceptanceZoneUrl.trim().startsWith("http"));
 
-        if (this.runAgainstLocalUaa) {
-            String path = this.uaaPath.isEmpty() ? "" : "/" + this.uaaPath;
-            this.acceptanceZoneUrl = "http://" + this.zoneSubdomain + "." + this.uaaRoute + path;
-        }
-        else {
-            this.acceptanceZoneUrl = "https://" + this.zoneSubdomain + "."  + this.publishedHost + "." + this.cfDomain;
-        }
         this.adminClientRestTemplate = (OAuth2RestTemplate) IntegrationTestUtils.getClientCredentialsTemplate(
                 IntegrationTestUtils.getClientCredentialsResource(this.acceptanceZoneUrl, new String[0], "admin", "acceptance-test"));
         this.instantiateIdentityClient();


### PR DESCRIPTION
Instead of specifying acceptance zone URL as a combination of zone subdomain, published host, and CF domain, use ACCEPTANCE_ZONE_URL, which is exported by the test running script. This simplifies test setup, and lets the test run against all local, CF and EKS environments.

- Modify JwtBearerGrantAT to read acceptance zone URL from environment variable
- Add acceptanceTest task to build.gradle to be able to execute JwtBearerGrantAT from IDE