### PR TITLE
Use default logger context configuration in UaaTokenServicesTests

### DIFF
--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServicesTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServicesTests.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
 import org.springframework.security.oauth2.provider.AuthorizationRequest;
@@ -40,6 +41,7 @@ import org.springframework.security.oauth2.provider.OAuth2Authentication;
 import org.springframework.security.oauth2.provider.TokenRequest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.util.ResourceUtils;
 
 import java.time.*;
 import java.util.ArrayList;
@@ -135,7 +137,7 @@ class UaaTokenServicesTests {
             private AbstractAppender appender;
 
             @BeforeEach
-            void addLoggerAppender() {
+            void addLoggerAppender() throws Exception {
                 appender = new AbstractAppender("", null, null) {
                     @Override
                     public void append(LogEvent event) {
@@ -145,6 +147,8 @@ class UaaTokenServicesTests {
                 appender.start();
 
                 LoggerContext context = (LoggerContext) LogManager.getContext(false);
+                context.setConfigLocation(ResourceUtils.toURI(
+                        new ClassPathResource("log4j2-test.properties").getFile().getAbsolutePath()));
                 context.getRootLogger().addAppender(appender);
             }
 


### PR DESCRIPTION
MockMvc UaaTokenServicesTests currently fail if executed after BootstrapTests because unable to find expected log message. While initializing UAA context [1] BootstrapTests trigger configuration of logger context [2] from Predix customized log4j2.properties file [3]. That modifies logging context to use Predix configuration for all MockMvc tests that execute after BootstrapTests. Since the additivity for the default log appender in Predix configuration is false [4], logs are not propagated to the appender used by UaaTokenServicesTests [5] nd tests break.

- Explicitly configure logger context from log4j2-test.properties for each test of UaaTokenServicesTests to ensure consistent test results

[1] https://github.com/GESoftware-CF/uaa/blob/predix_extensions_75.18.1/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/BootstrapTests.java#L216
[2] https://github.com/GESoftware-CF/uaa/blob/predix_extensions_75.18.1/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/YamlServletProfileInitializer.java#L209-L210
[3] https://github.com/GESoftware-CF/uaa/blob/predix_extensions_75.18.1/server/src/main/resources/log4j2.properties
[4] https://github.com/GESoftware-CF/uaa/blob/predix_extensions_75.18.1/server/src/main/resources/log4j2.properties#L25
[5] https://github.com/GESoftware-CF/uaa/blob/predix_extensions_75.18.1/uaa/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServicesTests.java#L138-L149