### PR TITLE
Orchestrator zone get api

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/zone/IdentityZoneProvisioning.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/zone/IdentityZoneProvisioning.java
@@ -22,6 +22,8 @@ public interface IdentityZoneProvisioning {
 
     IdentityZone retrieve(String id);
 
+    IdentityZone retrieveByName(String name);
+
     IdentityZone retrieveBySubdomain(String subdomain);
 
     List<IdentityZone> retrieveAll();

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/zone/JdbcIdentityZoneProvisioning.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/zone/JdbcIdentityZoneProvisioning.java
@@ -34,6 +34,8 @@ public class JdbcIdentityZoneProvisioning implements IdentityZoneProvisioning, S
 
     public static final String IDENTITY_ZONE_BY_ID_QUERY = IDENTITY_ZONES_QUERY + "where id=?";
 
+    public static final String IDENTITY_ZONE_BY_NAME_QUERY = IDENTITY_ZONES_QUERY + "where name=? and active = ?";
+
     public static final String IDENTITY_ZONE_BY_ID_QUERY_ACTIVE = IDENTITY_ZONE_BY_ID_QUERY + " and active = ?";
 
     public static final String IDENTITY_ZONE_BY_SUBDOMAIN_QUERY = "select " + ID_ZONE_FIELDS + " from identity_zone " + "where subdomain=? and active = ?";
@@ -54,6 +56,15 @@ public class JdbcIdentityZoneProvisioning implements IdentityZoneProvisioning, S
             return jdbcTemplate.queryForObject(IDENTITY_ZONE_BY_ID_QUERY_ACTIVE, mapper, id, true);
         } catch (EmptyResultDataAccessException x) {
             throw new ZoneDoesNotExistsException("Zone[" + id + "] not found.", x);
+        }
+    }
+
+    @Override
+    public IdentityZone retrieveByName(String name) {
+        try {
+            return jdbcTemplate.queryForObject(IDENTITY_ZONE_BY_NAME_QUERY, mapper, name, true);
+        } catch (EmptyResultDataAccessException x) {
+            throw new ZoneDoesNotExistsException("Zone[" + name + "] not found.", x);
         }
     }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,6 +8,7 @@ include(":cloudfoundry-identity-uaa")
 include(":cloudfoundry-identity-samples:cloudfoundry-identity-api")
 include(":cloudfoundry-identity-samples:cloudfoundry-identity-app")
 include(":cloudfoundry-identity-samples")
+include(":zone-service")
 
 project(":cloudfoundry-identity-metrics-data").projectDir = "$rootDir/metrics-data" as File
 project(":cloudfoundry-identity-model").projectDir = "$rootDir/model" as File
@@ -18,3 +19,5 @@ project(":cloudfoundry-identity-statsd-lib").projectDir = "$rootDir/statsd-lib" 
 project(":cloudfoundry-identity-samples:cloudfoundry-identity-api").projectDir = "$rootDir/samples/api" as File
 project(":cloudfoundry-identity-samples:cloudfoundry-identity-app").projectDir = "$rootDir/samples/app" as File
 project(":cloudfoundry-identity-samples").projectDir = "$rootDir/samples" as File
+project(":zone-service").projectDir = "$rootDir/zone-service" as File
+

--- a/uaa/build.gradle
+++ b/uaa/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     implementation(project(":cloudfoundry-identity-server")) {
         exclude(module: "jna")
     }
-
+    implementation(project(":zone-service"))
     implementation(project(":cloudfoundry-identity-statsd-lib"))
     implementation(libraries.springBootStarter)
     implementation(libraries.springBootStarterWeb){

--- a/uaa/src/main/resources/uaa.yml
+++ b/uaa/src/main/resources/uaa.yml
@@ -508,6 +508,8 @@ uaa:
     url: http://localhost:8080/uaa/approvals
   login:
     url: http://localhost:8080/uaa/authenticate
+  dashboard:
+    uri: http://localhost:8080/dashboard
   limitedFunctionality:
     enabled: false
     whitelist:

--- a/uaa/src/main/webapp/WEB-INF/spring/multitenant-endpoints.xml
+++ b/uaa/src/main/webapp/WEB-INF/spring/multitenant-endpoints.xml
@@ -20,6 +20,20 @@
           destroy-method="reset">
     </bean>
 
+    <http name="orchestratorZoneSecurity" pattern="/zones/**" create-session="stateless"
+          entry-point-ref="oauthAuthenticationEntryPoint"
+          use-expressions="true" authentication-manager-ref="emptyAuthenticationManager"
+          xmlns="http://www.springframework.org/schema/security">
+
+        <intercept-url pattern="/zones" access="#oauth2.hasScopeInAuthZone('zones.read') or #oauth2.hasScopeInAuthZone('zones.{zone.id}.admin') or #oauth2.hasScope('zones.write')" method="GET"/>
+        <intercept-url pattern="/**" access="denyAll"/>
+
+        <custom-filter ref="resourceAgnosticAuthenticationFilter" before="PRE_AUTH_FILTER"/>
+        <access-denied-handler ref="oauthAccessDeniedHandler"/>
+        <expression-handler ref="oauthWebExpressionHandler"/>
+        <csrf disabled="true"/>
+    </http>
+
     <http name="identityZoneSecurity" pattern="/identity-zones/**" create-session="stateless"
           entry-point-ref="oauthAuthenticationEntryPoint"
           use-expressions="true" authentication-manager-ref="emptyAuthenticationManager"

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/zones/ZoneControllerMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/zones/ZoneControllerMockMvcTests.java
@@ -1,0 +1,244 @@
+package org.cloudfoundry.identity.uaa.mock.zones;
+
+import static org.cloudfoundry.identity.uaa.zone.ZoneService.X_IDENTITY_ZONE_ID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.util.StringUtils.hasText;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import lombok.SneakyThrows;
+import net.bytebuddy.utility.RandomString;
+import org.cloudfoundry.identity.uaa.DefaultTestContext;
+import org.cloudfoundry.identity.uaa.login.util.RandomValueStringGenerator;
+import org.cloudfoundry.identity.uaa.test.TestClient;
+import org.cloudfoundry.identity.uaa.util.JsonUtils;
+import org.cloudfoundry.identity.uaa.zone.IdentityZone;
+import org.cloudfoundry.identity.uaa.zone.IdentityZoneConfiguration;
+import org.cloudfoundry.identity.uaa.zone.model.ZoneResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.oauth2.provider.ClientRegistrationService;
+import org.springframework.security.oauth2.provider.client.BaseClientDetails;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.web.context.WebApplicationContext;
+
+@DefaultTestContext
+public class ZoneControllerMockMvcTests {
+
+    private MockMvc mockMvc;
+    private String identityClientZonesReadToken = null;
+    private String uaaAdminClientToken;
+
+    private final String serviceProviderKey =
+        "-----BEGIN RSA PRIVATE KEY-----\n" +
+        "MIICXQIBAAKBgQDHtC5gUXxBKpEqZTLkNvFwNGnNIkggNOwOQVNbpO0WVHIivig5\n" +
+        "L39WqS9u0hnA+O7MCA/KlrAR4bXaeVVhwfUPYBKIpaaTWFQR5cTR1UFZJL/OF9vA\n" +
+        "fpOwznoD66DDCnQVpbCjtDYWX+x6imxn8HCYxhMol6ZnTbSsFW6VZjFMjQIDAQAB\n" +
+        "AoGAVOj2Yvuigi6wJD99AO2fgF64sYCm/BKkX3dFEw0vxTPIh58kiRP554Xt5ges\n" +
+        "7ZCqL9QpqrChUikO4kJ+nB8Uq2AvaZHbpCEUmbip06IlgdA440o0r0CPo1mgNxGu\n" +
+        "lhiWRN43Lruzfh9qKPhleg2dvyFGQxy5Gk6KW/t8IS4x4r0CQQD/dceBA+Ndj3Xp\n" +
+        "ubHfxqNz4GTOxndc/AXAowPGpge2zpgIc7f50t8OHhG6XhsfJ0wyQEEvodDhZPYX\n" +
+        "kKBnXNHzAkEAyCA76vAwuxqAd3MObhiebniAU3SnPf2u4fdL1EOm92dyFs1JxyyL\n" +
+        "gu/DsjPjx6tRtn4YAalxCzmAMXFSb1qHfwJBAM3qx3z0gGKbUEWtPHcP7BNsrnWK\n" +
+        "vw6By7VC8bk/ffpaP2yYspS66Le9fzbFwoDzMVVUO/dELVZyBnhqSRHoXQcCQQCe\n" +
+        "A2WL8S5o7Vn19rC0GVgu3ZJlUrwiZEVLQdlrticFPXaFrn3Md82ICww3jmURaKHS\n" +
+        "N+l4lnMda79eSp3OMmq9AkA0p79BvYsLshUJJnvbk76pCjR28PK4dV1gSDUEqQMB\n" +
+        "qy45ptdwJLqLJCeNoR0JUcDNIRhOCuOPND7pcMtX6hI/\n" +
+        "-----END RSA PRIVATE KEY-----";
+
+    private final String serviceProviderKeyPassword = "password";
+
+    private final String serviceProviderCertificate =
+        "-----BEGIN CERTIFICATE-----\n" +
+        "MIIDSTCCArKgAwIBAgIBADANBgkqhkiG9w0BAQQFADB8MQswCQYDVQQGEwJhdzEO\n" +
+        "MAwGA1UECBMFYXJ1YmExDjAMBgNVBAoTBWFydWJhMQ4wDAYDVQQHEwVhcnViYTEO\n" +
+        "MAwGA1UECxMFYXJ1YmExDjAMBgNVBAMTBWFydWJhMR0wGwYJKoZIhvcNAQkBFg5h\n" +
+        "cnViYUBhcnViYS5hcjAeFw0xNTExMjAyMjI2MjdaFw0xNjExMTkyMjI2MjdaMHwx\n" +
+        "CzAJBgNVBAYTAmF3MQ4wDAYDVQQIEwVhcnViYTEOMAwGA1UEChMFYXJ1YmExDjAM\n" +
+        "BgNVBAcTBWFydWJhMQ4wDAYDVQQLEwVhcnViYTEOMAwGA1UEAxMFYXJ1YmExHTAb\n" +
+        "BgkqhkiG9w0BCQEWDmFydWJhQGFydWJhLmFyMIGfMA0GCSqGSIb3DQEBAQUAA4GN\n" +
+        "ADCBiQKBgQDHtC5gUXxBKpEqZTLkNvFwNGnNIkggNOwOQVNbpO0WVHIivig5L39W\n" +
+        "qS9u0hnA+O7MCA/KlrAR4bXaeVVhwfUPYBKIpaaTWFQR5cTR1UFZJL/OF9vAfpOw\n" +
+        "znoD66DDCnQVpbCjtDYWX+x6imxn8HCYxhMol6ZnTbSsFW6VZjFMjQIDAQABo4Ha\n" +
+        "MIHXMB0GA1UdDgQWBBTx0lDzjH/iOBnOSQaSEWQLx1syGDCBpwYDVR0jBIGfMIGc\n" +
+        "gBTx0lDzjH/iOBnOSQaSEWQLx1syGKGBgKR+MHwxCzAJBgNVBAYTAmF3MQ4wDAYD\n" +
+        "VQQIEwVhcnViYTEOMAwGA1UEChMFYXJ1YmExDjAMBgNVBAcTBWFydWJhMQ4wDAYD\n" +
+        "VQQLEwVhcnViYTEOMAwGA1UEAxMFYXJ1YmExHTAbBgkqhkiG9w0BCQEWDmFydWJh\n" +
+        "QGFydWJhLmFyggEAMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEEBQADgYEAYvBJ\n" +
+        "0HOZbbHClXmGUjGs+GS+xC1FO/am2suCSYqNB9dyMXfOWiJ1+TLJk+o/YZt8vuxC\n" +
+        "KdcZYgl4l/L6PxJ982SRhc83ZW2dkAZI4M0/Ud3oePe84k8jm3A7EvH5wi5hvCkK\n" +
+        "RpuRBwn3Ei+jCRouxTbzKPsuCVB+1sNyxMTXzf0=\n" +
+        "-----END CERTIFICATE-----\n";
+
+    @BeforeEach
+    void setUp(@Autowired WebApplicationContext webApplicationContext, @Autowired MockMvc mockMvc,
+               @Autowired TestClient testClient, @Autowired ClientRegistrationService clientRegistrationService)
+        throws Exception {
+        this.mockMvc = mockMvc;
+        BaseClientDetails uaaAdminClient = new BaseClientDetails("uaa-admin-" + RandomString.make(5).toLowerCase(),
+                                                                 null,
+                                                                 "uaa.admin",
+                                                                 "password,client_credentials",
+                                                                 "uaa.admin");
+        uaaAdminClient.setClientSecret("secret");
+        clientRegistrationService.addClientDetails(uaaAdminClient);
+        identityClientZonesReadToken = testClient.getClientCredentialsOAuthAccessToken(
+            "identity",
+            "identitysecret",
+            "zones.read");
+        uaaAdminClientToken = testClient.getClientCredentialsOAuthAccessToken(
+            uaaAdminClient.getClientId(),
+            "secret",
+            "uaa.admin");
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(IdentityZonesBaseUrlsArgumentsSource.class)
+    void testGetZone_unAuthorized(String url) throws Exception {
+        mockMvc.perform(get(url))
+               .andExpect(status().isUnauthorized());
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(NameRequiredArgumentsSource.class)
+    void testGetZone_nameRequiredError(String url) throws Exception {
+        MvcResult result = mockMvc.perform(
+                                      get(url)
+                                          .header("Authorization", "Bearer " + identityClientZonesReadToken))
+                                  .andExpect(status().isBadRequest()).andReturn();
+        assertEquals(
+            "{\"message\", \"Required request parameter 'name' for method parameter type String is not present\" }",
+            result.getResponse().getContentAsString());
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(NameNotEmptyArgumentsSource.class)
+    void testGetZone_nameEmptyError(String url) throws Exception {
+        MvcResult result = mockMvc.perform(
+                                      get(url)
+                                          .header("Authorization", "Bearer " + identityClientZonesReadToken))
+                                  .andExpect(status().isBadRequest()).andReturn();
+        assertEquals(
+            "{\"message\", \"getZone.name: must not be empty\" }",
+            result.getResponse().getContentAsString());
+    }
+
+    @Test
+    void testGetZone() throws Exception {
+        //TODO: remove this createIdentityZone method once the create orchestrator zone API is implemented and use it to create zone.
+        IdentityZone identityZone = createIdentityZone();
+        MvcResult result = mockMvc.perform(
+                                      get("/zones").param("name", "test-name")
+                                                   .header("Authorization", "Bearer " + identityClientZonesReadToken))
+                                  .andExpect(status().isAccepted()).andReturn();
+        ZoneResponse zoneResponse =
+            JsonUtils.readValue(result.getResponse().getContentAsString(), ZoneResponse.class);
+        assertNotNull(zoneResponse);
+        assertNotNull(identityZone);
+        assertNotNull(zoneResponse.getParameters());
+        assertEquals(identityZone.getSubdomain(), zoneResponse.getParameters().getSubdomain());
+        assertEquals(identityZone.getSubdomain(), zoneResponse.getConnectionDetails().getSubdomain());
+        String uri = "http://" + identityZone.getSubdomain() + ".localhost";
+        assertEquals(uri, zoneResponse.getConnectionDetails().getUri());
+        assertEquals("http://localhost:8080/dashboard", zoneResponse.getConnectionDetails().getDashboardUri());
+        assertEquals(uri + "/oauth/token", zoneResponse.getConnectionDetails().getIssuerId());
+        assertEquals(X_IDENTITY_ZONE_ID, zoneResponse.getConnectionDetails().getZone().getHttpHeaderName());
+        assertEquals(identityZone.getId(), zoneResponse.getConnectionDetails().getZone().getHttpHeaderValue());
+    }
+
+    @Test
+    void testGetZone_Notfound() throws Exception {
+        MvcResult result = mockMvc.perform(
+                   get("/zones").param("name", "random-name")
+                                .header("Authorization", "Bearer " + identityClientZonesReadToken))
+               .andExpect(status().isNotFound()).andReturn();
+        assertEquals(
+            "{\"message\", \"Zone[random-name] not found.\" }",
+            result.getResponse().getContentAsString());
+    }
+
+    //TODO: delete once the orchestrator create API implemented
+    @SneakyThrows
+    private IdentityZone createIdentityZone() {
+        IdentityZone identityZone = createSimpleIdentityZone(RandomString.make(10));
+        IdentityZoneConfiguration identityZoneConfiguration = new IdentityZoneConfiguration();
+        Map<String, String> keys = new HashMap<>();
+        keys.put("kid", "key");
+        identityZoneConfiguration.getTokenPolicy().setKeys(keys);
+        identityZoneConfiguration.getTokenPolicy().setActiveKeyId("kid");
+        identityZoneConfiguration.getTokenPolicy().setKeys(keys);
+
+        identityZone.setConfig(identityZoneConfiguration);
+        identityZone.getConfig().getSamlConfig().setPrivateKey(serviceProviderKey);
+        identityZone.getConfig().getSamlConfig().setPrivateKeyPassword(serviceProviderKeyPassword);
+        identityZone.getConfig().getSamlConfig().setCertificate(serviceProviderCertificate);
+        MvcResult result = mockMvc.perform(
+                                      post("/identity-zones")
+                                          .header("Authorization", "Bearer " + uaaAdminClientToken)
+                                          .contentType(APPLICATION_JSON)
+                                          .content(JsonUtils.writeValueAsString(identityZone)))
+                                  .andExpect(status().is(HttpStatus.CREATED.value()))
+                                  .andReturn();
+
+            return JsonUtils.readValue(result.getResponse().getContentAsString(), IdentityZone.class);
+    }
+
+    //TODO: delete once the orchestrator create API implemented
+    private IdentityZone createSimpleIdentityZone(String id) {
+        IdentityZone identityZone = new IdentityZone();
+        identityZone.setId(id);
+        identityZone.setSubdomain(hasText(id) ? id : new RandomValueStringGenerator().generate());
+        identityZone.setName("test-name");
+        identityZone.setDescription("Like the Twilight Zone but tastier.");
+        return identityZone;
+    }
+
+    private static class IdentityZonesBaseUrlsArgumentsSource implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            return Stream.of(
+                Arguments.of("/zones"),
+                Arguments.of("/zones/"),
+                Arguments.of("/zones/test")
+                            );
+        }
+    }
+
+    private static class NameNotEmptyArgumentsSource implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            return Stream.of(
+                Arguments.of("/zones?name="),
+                Arguments.of("/zones?name= ")
+                            );
+        }
+    }
+
+    private static class NameRequiredArgumentsSource implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            return Stream.of(
+                Arguments.of("/zones?name"),
+                Arguments.of("/zones")
+                            );
+        }
+    }
+}

--- a/uaa/src/test/resources/integration_test_properties.yml
+++ b/uaa/src/test/resources/integration_test_properties.yml
@@ -168,6 +168,8 @@ NUREGO_API_URL: https://am-staging.nurego.com
 uaa:
   # The hostname of the UAA that this login server will connect to
   url: http://localhost:8080/uaa
+  dashboard:
+    uri: http://localhost:8080/dashboard
   token:
     url: http://localhost:8080/uaa/oauth/token
   approvals:

--- a/zone-service/build.gradle
+++ b/zone-service/build.gradle
@@ -1,0 +1,27 @@
+plugins {
+    id 'java'
+}
+
+group 'org.cloudfoundry.identity'
+version '75.18.1'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation(libraries.springBootStarter)
+    implementation(libraries.springBootStarterWeb){
+        exclude(group: "org.glassfish", module: "jakarta.el")
+    }
+    implementation(project(":cloudfoundry-identity-server"))
+    implementation(project(":cloudfoundry-identity-model"))
+    implementation(libraries.hibernateValidator)
+    implementation(libraries.slf4jImpl)
+    implementation(libraries.log4jCore)
+    testImplementation(libraries.springBootStarterTest)
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/ZoneConfiguration.java
+++ b/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/ZoneConfiguration.java
@@ -1,0 +1,18 @@
+package org.cloudfoundry.identity.uaa.zone;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ZoneConfiguration {
+
+    @Bean
+    @ConditionalOnProperty({ "uaa.dashboard.uri" })
+    public ZoneService zoneService(IdentityZoneProvisioning zoneProvisioning,
+                                   @Value("${uaa.dashboard.uri}") String uaaDashboardUri) {
+        return new ZoneService(zoneProvisioning, uaaDashboardUri);
+    }
+
+}

--- a/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/ZoneController.java
+++ b/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/ZoneController.java
@@ -1,0 +1,75 @@
+package org.cloudfoundry.identity.uaa.zone;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+import javax.validation.ConstraintViolationException;
+import javax.validation.constraints.NotBlank;
+
+import org.cloudfoundry.identity.uaa.zone.model.ZoneResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@RestController("zoneEndpoints")
+@RequestMapping("/zones")
+public class ZoneController {
+
+    private static final Logger logger = LoggerFactory.getLogger(ZoneController.class);
+    private final ZoneService zoneService;
+
+    public static final String MANDATORY_VALIDATION_MESSAGE = "must not be empty";
+
+    public ZoneController(ZoneService zoneService) {
+        this.zoneService = zoneService;
+    }
+
+    @GetMapping
+    public ResponseEntity<ZoneResponse> getZone(@NotBlank(message = MANDATORY_VALIDATION_MESSAGE) @RequestParam String name) {
+        return new ResponseEntity<>(zoneService.getZoneDetails(name), HttpStatus.ACCEPTED);
+    }
+
+    @ExceptionHandler(ZoneDoesNotExistsException.class)
+    public ResponseEntity<String> handleZoneDoesNotExistsException(ZoneDoesNotExistsException e) {
+        return new ResponseEntity<>("{\"message\", \""+ e.getMessage() +"\" }", NOT_FOUND);
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<String> handleMessageReadableException(HttpMessageNotReadableException e) {
+        return new ResponseEntity<>("{\"message\",\"Request failed due to a validation error.\" }", BAD_REQUEST);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<String> handleValidationException(MethodArgumentNotValidException e) {
+        return new ResponseEntity<>("{\"message\", \""+ e.getMessage() +"\" }", BAD_REQUEST);
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<String> handleMissingRequestParamException(MissingServletRequestParameterException e) {
+        return new ResponseEntity<>("{\"message\", \""+ e.getMessage() +"\" }", BAD_REQUEST);
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<String> handleConstraintViolationException(ConstraintViolationException e) {
+        return new ResponseEntity<>("{\"message\", \""+ e.getMessage() +"\" }", BAD_REQUEST);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<String> handleException(Exception e) {
+        logger.error(e.getClass() + ": " + e.getMessage(), e);
+        return new ResponseEntity<>("{\"message\",\"Server Error.\" }", INTERNAL_SERVER_ERROR);
+    }
+
+}

--- a/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/ZoneService.java
+++ b/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/ZoneService.java
@@ -1,0 +1,51 @@
+package org.cloudfoundry.identity.uaa.zone;
+
+import java.net.URI;
+
+import org.cloudfoundry.identity.uaa.zone.model.ConnectionDetails;
+import org.cloudfoundry.identity.uaa.zone.model.Zone;
+import org.cloudfoundry.identity.uaa.zone.model.ZoneHeader;
+import org.cloudfoundry.identity.uaa.zone.model.ZoneResponse;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+public class ZoneService {
+
+    public static final String X_IDENTITY_ZONE_ID = "X-Identity-Zone-Id";
+
+    private final IdentityZoneProvisioning zoneProvisioning;
+    private final String uaaDashboardUri;
+
+    public ZoneService(IdentityZoneProvisioning zoneProvisioning, String uaaDashboardUri) {
+        this.zoneProvisioning = zoneProvisioning;
+        this.uaaDashboardUri = uaaDashboardUri;
+    }
+
+    public ZoneResponse getZoneDetails(String zoneName) {
+        IdentityZone identityZone = zoneProvisioning.retrieveByName(zoneName);
+        Zone zone = new Zone(null, identityZone.getSubdomain());
+        String uaaUri = ServletUriComponentsBuilder.fromCurrentContextPath().toUriString();
+        String zoneUri = getZoneUri(identityZone.getSubdomain(), uaaUri);
+        ConnectionDetails connectionDetails = buildConnectionDetails(zoneName, identityZone, zoneUri);
+        return new ZoneResponse(zoneName, zone, connectionDetails);
+    }
+
+    private ConnectionDetails buildConnectionDetails(String zoneName, IdentityZone identityZone,
+                                                            String zoneUri) {
+        ConnectionDetails connectionDetails = new ConnectionDetails();
+        connectionDetails.setUri(zoneUri);
+        connectionDetails.setIssuerId(zoneUri + "/oauth/token");
+        connectionDetails.setSubdomain(identityZone.getSubdomain());
+        connectionDetails.setDashboardUri(uaaDashboardUri);
+        ZoneHeader zoneHeader = new ZoneHeader(X_IDENTITY_ZONE_ID, identityZone.getId());
+        connectionDetails.setZone(zoneHeader);
+        return connectionDetails;
+    }
+
+    private String getZoneUri(String subdomain, String uaaUri) {
+        URI uaaUriObject = URI.create(uaaUri);
+        String currentUAAHostName = uaaUriObject.getHost();
+        URI newUAARoute = URI
+            .create(uaaUriObject.toString().replace(currentUAAHostName, subdomain + "." + currentUAAHostName));
+        return newUAARoute.toString();
+    }
+}

--- a/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/model/ConnectionDetails.java
+++ b/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/model/ConnectionDetails.java
@@ -1,0 +1,12 @@
+package org.cloudfoundry.identity.uaa.zone.model;
+
+import lombok.Data;
+
+@Data
+public class ConnectionDetails {
+    private String uri;
+    private String dashboardUri;
+    private String issuerId;
+    private String subdomain;
+    private ZoneHeader zone;
+}

--- a/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/model/Zone.java
+++ b/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/model/Zone.java
@@ -1,0 +1,16 @@
+package org.cloudfoundry.identity.uaa.zone.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonInclude(Include.NON_NULL)
+public class Zone {
+    private String adminSecret;
+    private String subdomain;
+}

--- a/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/model/ZoneHeader.java
+++ b/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/model/ZoneHeader.java
@@ -1,0 +1,15 @@
+package org.cloudfoundry.identity.uaa.zone.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ZoneHeader {
+
+    private String httpHeaderName;
+    private String httpHeaderValue;
+
+}

--- a/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/model/ZoneRequest.java
+++ b/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/model/ZoneRequest.java
@@ -1,0 +1,9 @@
+package org.cloudfoundry.identity.uaa.zone.model;
+
+import lombok.Data;
+
+@Data
+public class ZoneRequest {
+    private String name;
+    private Zone parameters;
+}

--- a/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/model/ZoneResponse.java
+++ b/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/model/ZoneResponse.java
@@ -1,0 +1,19 @@
+package org.cloudfoundry.identity.uaa.zone.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonInclude(Include.NON_NULL)
+public class ZoneResponse {
+
+    private String name;
+    private Zone parameters;
+    private ConnectionDetails connectionDetails;
+
+}

--- a/zone-service/src/test/java/org/cloudfoundry/identity/uaa/zone/ZoneServiceTests.java
+++ b/zone-service/src/test/java/org/cloudfoundry/identity/uaa/zone/ZoneServiceTests.java
@@ -1,0 +1,68 @@
+package org.cloudfoundry.identity.uaa.zone;
+
+import static org.cloudfoundry.identity.uaa.zone.ZoneService.X_IDENTITY_ZONE_ID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import net.bytebuddy.utility.RandomString;
+import org.cloudfoundry.identity.uaa.zone.model.ZoneResponse;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+public class ZoneServiceTests {
+
+    public static final String ZONE_NAME = "The Twiglet Zone";
+    private ZoneService zoneService;
+    private IdentityZoneProvisioning zoneProvisioning;
+
+    @BeforeEach
+    public void beforeEachTest() {
+        zoneProvisioning = Mockito.mock(IdentityZoneProvisioning.class);
+        zoneService = new ZoneService(zoneProvisioning, "http://localhost/dashboard");
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+    }
+
+    @Test
+    public void testGetZoneDetails() {
+        IdentityZone identityZone = buildIdentityZone();
+        when(zoneProvisioning.retrieveByName(any())).thenReturn(identityZone);
+        ZoneResponse zone = zoneService.getZoneDetails(ZONE_NAME);
+        assertNotNull(zone);
+        assertEquals(zone.getName(), ZONE_NAME);
+        String uri = "http://" + identityZone.getSubdomain() + ".localhost";
+        assertEquals(zone.getParameters().getSubdomain(), identityZone.getSubdomain());
+        assertEquals(zone.getConnectionDetails().getSubdomain(), identityZone.getSubdomain());
+        assertEquals((zone.getConnectionDetails().getUri()), uri);
+        assertEquals(zone.getConnectionDetails().getDashboardUri(), "http://localhost/dashboard");
+        assertEquals(zone.getConnectionDetails().getIssuerId(), uri + "/oauth/token");
+        assertEquals(zone.getConnectionDetails().getZone().getHttpHeaderName(), X_IDENTITY_ZONE_ID);
+        assertEquals(zone.getConnectionDetails().getZone().getHttpHeaderValue(), identityZone.getId());
+    }
+
+    @Test
+    public void testGetZoneDetails_NotFound() {
+        when(zoneProvisioning.retrieveByName(any())).thenThrow(new ZoneDoesNotExistsException("Zone not available."));
+        ZoneDoesNotExistsException exception =
+            Assertions.assertThrows(ZoneDoesNotExistsException.class, () -> zoneService.getZoneDetails("random-string"),
+                                    "Not found exception not thrown");
+        assertTrue(exception.getMessage().contains("Zone not available."));
+    }
+
+    private IdentityZone buildIdentityZone() {
+        IdentityZone identityZone = new IdentityZone();
+        identityZone.setId(RandomString.make(10));
+        identityZone.setSubdomain(RandomString.make(10).toLowerCase());
+        identityZone.setName(ZONE_NAME);
+        identityZone.setDescription("Like the Twilight Zone but tastier.");
+        return identityZone;
+    }
+}


### PR DESCRIPTION
Create new module for zone-service and create configurations required
for new module. Update settings.gradle to include the new module and
directory.

Add dashboard uri required in the zone response to uaa.yml for main and
integration_test_properties.yml for test. This property has to configure
for each environment.

Create controller class for zone and add get method based on
documentation [1]
Add validation and exceptions and customize the error message specific
for orchestrator zone contract.
Create a new service for zone and reuse the DAO class from identity zone
. Write a new method in identity zone dao class to fetch identity zone
by name. Reuse the exiting query and add condition for name and active.
Build the response based on the format specified in the document [1].

Update spring security config to include orchestrator zone get API. Copy
the configuration from identity zone and use it for orchestrator zone.

Create model class based on the structure defined in the confluence [1].
Add lombok annotations for getter/setter and constructor.

Add unit tests for ZoneService using Mockito and cover all the scenario.

Add Mockmvc tests for ZoneController using Spring mock mvc. Copy the
configurations from existing test. Cover all the scenario and
validations.

Add Integration tests for ZoneController and copy the required
configuration from Identity zone integrations tests.

Also write the test cases for newly written DAO class.

[1] https://devcloud.swcoe.ge.com/devspace/display/RMOCM/Orchestrator+UAA+Zone+provisioning+API#OrchestratorUAAZoneprovisioningAPI-GETAPI