### PR TITLE
Set default tag for docker image to build branch name

### DIFF
--- a/gesos-image-build.pipeline
+++ b/gesos-image-build.pipeline
@@ -18,7 +18,7 @@ pipeline {
         )
         string(
             name: 'IMAGE_TAG',
-            defaultValue: 'BUILD_TAG_FROM_BRANCH_NAME',
+            defaultValue: BRANCH_NAME,
             description: 'Tag for docker image to push to ECR'
         )
     }
@@ -41,11 +41,7 @@ pipeline {
             steps {
                 script {
                     setBuildStatus(repoStatusReportUrl, gitCommitStatusContext, 'in progress', 'pending')
-                    imageTag = params.IMAGE_TAG
-                    if (imageTag == 'BUILD_TAG_FROM_BRANCH_NAME') {
-                        imageTag = BRANCH_NAME.replaceAll('_', '.')
-                    }
-                    currentBuild.displayName = "#${env.BUILD_NUMBER} (IAM Container Config Branch Name: ${params.IAM_CONTAINER_CONFIG_BRANCH_NAME}, Image Tag: ${imageTag})"
+                    currentBuild.displayName = "#${env.BUILD_NUMBER} (IAM Container Config Branch Name: ${params.IAM_CONTAINER_CONFIG_BRANCH_NAME}, Image Tag: ${params.IMAGE_TAG})"
                     result = sh(
                         script: """
                                     curl -sSL -X POST -H 'x-api-key: ${GESOS_API_KEY}' \\
@@ -57,7 +53,7 @@ pipeline {
                                                       "pre_build_script":"pre-build.sh", \
                                                       "image_name": "iam-uaa", \
                                                       "contact_emails": "${API_BUILD_STATUS_EMAIL_RECIPIENTS}", \
-                                                      "releaseTag1": "${imageTag}", \
+                                                      "releaseTag1": "${params.IMAGE_TAG}", \
                                                       "release": "True" \
                                                     }' \\
                                         '${GESOS_BUILD_REQUEST_URL}'


### PR DESCRIPTION
By default, tag for UAA docker image built by GE SOS is set to build branch name. For example, tag for image built from rc_75.18.3 branch is set to rc_75.18.3 and for image built from release_75.18.3 branch is set to release_75.18.3. Default tag name could be overwritten by IMAGE_TAG parameter of GE SSO Build pipeline

- Set default value for IMAGE_TAG parameter in gesos-image-build.pipeline to the build branch name.