### PR TITLE
Zone Delete and Update fix

### DIFF
--- a/uaa/src/main/webapp/WEB-INF/spring/multitenant-endpoints.xml
+++ b/uaa/src/main/webapp/WEB-INF/spring/multitenant-endpoints.xml
@@ -26,8 +26,8 @@
           xmlns="http://www.springframework.org/schema/security">
 
         <intercept-url pattern="/orchestrator/zones" access="#oauth2.hasScopeInAuthZone('zones.read') or #oauth2.hasScopeInAuthZone('zones.{zone.id}.admin') or #oauth2.hasScope('zones.write')" method="GET"/>
-        <intercept-url pattern="/orchestrator/zones" access="#oauth2.hasScopeInAuthZone('zones.read') or #oauth2.hasScopeInAuthZone('zones.{zone.id}.admin') or #oauth2.hasScope('zones.write')" method="DELETE"/>
-        <intercept-url pattern="/orchestrator/zones" access="#oauth2.hasScopeInAuthZone('zones.read') or #oauth2.hasScopeInAuthZone('zones.{zone.id}.admin') or #oauth2.hasScope('zones.write')" method="PUT"/>
+        <intercept-url pattern="/orchestrator/zones" access="#oauth2.hasScopeInAuthZone('zones.{zone.id}.admin') or #oauth2.hasScope('zones.write')" method="DELETE"/>
+        <intercept-url pattern="/orchestrator/zones" access="#oauth2.hasScopeInAuthZone('zones.{zone.id}.admin') or #oauth2.hasScope('zones.write')" method="PUT"/>
 
         <intercept-url pattern="/**" access="denyAll"/>
 

--- a/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/OrchestratorZoneService.java
+++ b/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/OrchestratorZoneService.java
@@ -22,8 +22,9 @@ public class OrchestratorZoneService implements ApplicationEventPublisherAware {
 
     public static final String X_IDENTITY_ZONE_ID = "X-Identity-Zone-Id";
     public static final String CLIENT_ID = "admin";
-    public static final String ZONE_AUTHORITIES = "clients.admin,clients.read,clients.write,clients.secret,idps.read,idps.write,sps" +
-                                                  ".read,sps.write,scim.read,scim.write,uaa.resource";
+    public static final String ZONE_AUTHORITIES =
+        "clients.admin,clients.read,clients.write,clients.secret,idps.read,idps.write,sps" +
+        ".read,sps.write,scim.read,scim.write,uaa.resource";
     public static final String GRANT_TYPES = "client_credentials";
     public static final String RESOURCE_IDS = "none";
     public static final String SCOPES = "uaa.none";
@@ -32,7 +33,7 @@ public class OrchestratorZoneService implements ApplicationEventPublisherAware {
     private static final java.util.Base64.Encoder base64encoder = java.util.Base64.getMimeEncoder(64, "\n".getBytes());
 
     private final IdentityZoneProvisioning zoneProvisioning;
-   private final String uaaDashboardUri;
+    private final String uaaDashboardUri;
     private ApplicationEventPublisher publisher;
 
     private static final Logger logger = LoggerFactory.getLogger(OrchestratorZoneService.class);
@@ -59,7 +60,9 @@ public class OrchestratorZoneService implements ApplicationEventPublisherAware {
             IdentityZone zone = zoneProvisioning.retrieveByName(zoneName);
             IdentityZoneHolder.set(zone);
             if (publisher != null && zone != null) {
-                publisher.publishEvent(new EntityDeletedEvent<>(zone, SecurityContextHolder.getContext().getAuthentication(), IdentityZoneHolder.getCurrentZoneId()));
+                publisher.publishEvent(
+                    new EntityDeletedEvent<>(zone, SecurityContextHolder.getContext().getAuthentication(),
+                                             IdentityZoneHolder.getCurrentZoneId()));
                 logger.debug("Zone - deleted id[" + zone.getId() + "]");
                 return new ResponseEntity<>(ACCEPTED);
             } else {
@@ -71,7 +74,7 @@ public class OrchestratorZoneService implements ApplicationEventPublisherAware {
     }
 
     private ConnectionDetails buildConnectionDetails(String zoneName, IdentityZone identityZone,
-                                                            String zoneUri) {
+                                                     String zoneUri) {
         ConnectionDetails connectionDetails = new ConnectionDetails();
         connectionDetails.setUri(zoneUri);
         connectionDetails.setIssuerId(zoneUri + "/oauth/token");

--- a/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/model/OrchestratorZone.java
+++ b/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/model/OrchestratorZone.java
@@ -11,6 +11,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @JsonInclude(Include.NON_NULL)
 public class OrchestratorZone {
-    private String adminSecret;
+    private String adminClientSecret;
     private String subdomain;
 }


### PR DESCRIPTION
Zones DELETE and UPDATE require zones admin or write token scopes.
Update the test case read token for get operation and write token for
delete and update operation
Also rename to adminClientSecret instead or adminSecret
Some lines are mess in OrchestratorZoneService and format it properly.