### PR TITLE
Remove org.hibernate dependency

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -101,6 +101,7 @@ dependencies {
         exclude(module: 'httpclient')
         //excluded to avoid bringing in jackson core < 2.9
         exclude(module: 'predix-event-hub-sdk')
+        exclude(group: 'org.hibernate')
     }
     implementation(libraries.springLogFilter) {
         exclude(group: 'ch.qos.logback')


### PR DESCRIPTION
Remove the org.hibernate dependency, since it is a deprecated one. This is conflict with org.hibernatae.validate group and validation(NotBlank) is failing in the deployment.
Audit having the deprecated hibernate dependency and exclude it from the
 build.gradle.