### PR TITLE
Create POST API for Orchestrator contract

### DIFF
--- a/uaa/src/main/webapp/WEB-INF/spring/multitenant-endpoints.xml
+++ b/uaa/src/main/webapp/WEB-INF/spring/multitenant-endpoints.xml
@@ -24,7 +24,7 @@
           entry-point-ref="oauthAuthenticationEntryPoint"
           use-expressions="true" authentication-manager-ref="emptyAuthenticationManager"
           xmlns="http://www.springframework.org/schema/security">
-
+        <intercept-url pattern="/orchestrator/zones" access="#oauth2.hasScopeInAuthZone('zones.{zone.id}.admin') or #oauth2.hasScope('zones.write')" method="POST"/>
         <intercept-url pattern="/orchestrator/zones" access="#oauth2.hasScopeInAuthZone('zones.read') or #oauth2.hasScopeInAuthZone('zones.{zone.id}.admin') or #oauth2.hasScope('zones.write')" method="GET"/>
         <intercept-url pattern="/orchestrator/zones" access="#oauth2.hasScopeInAuthZone('zones.{zone.id}.admin') or #oauth2.hasScope('zones.write')" method="DELETE"/>
         <intercept-url pattern="/orchestrator/zones" access="#oauth2.hasScopeInAuthZone('zones.{zone.id}.admin') or #oauth2.hasScope('zones.write')" method="PUT"/>

--- a/zone-service/build.gradle
+++ b/zone-service/build.gradle
@@ -16,10 +16,18 @@ dependencies {
     implementation(libraries.springSecurityWeb)
     implementation(project(":cloudfoundry-identity-server"))
     implementation(project(":cloudfoundry-identity-model"))
+    implementation(project(":cloudfoundry-identity-metrics-data"))
     implementation(libraries.hibernateValidator)
     implementation(libraries.slf4jImpl)
     implementation(libraries.log4jCore)
+    implementation(libraries.bouncyCastleProv)
+    implementation(libraries.bouncyCastlePkix)
     testImplementation(libraries.springBootStarterTest)
+    implementation(libraries.springSecurityOauth) {
+        exclude(module: "commons-codec")
+        exclude(module: "jackson-mapper-asl")
+        exclude(module: "spring-security-web")
+    }
 }
 
 test {

--- a/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/OrchestratorZoneConfiguration.java
+++ b/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/OrchestratorZoneConfiguration.java
@@ -1,18 +1,32 @@
 package org.cloudfoundry.identity.uaa.zone;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.cloudfoundry.identity.uaa.provider.IdentityProviderProvisioning;
+import org.cloudfoundry.identity.uaa.provider.IdentityProvider;
+import org.cloudfoundry.identity.uaa.provider.UaaIdentityProviderDefinition;
+import org.cloudfoundry.identity.uaa.scim.ScimGroupProvisioning;
+import org.cloudfoundry.identity.uaa.resources.QueryableResourceManager;
+import org.cloudfoundry.identity.uaa.client.ClientDetailsValidator;
+import org.springframework.security.oauth2.provider.ClientDetails;
 
 @Configuration
 public class OrchestratorZoneConfiguration {
 
     @Bean
     @ConditionalOnProperty({ "uaa.dashboard.uri" })
-    public OrchestratorZoneService zoneService(IdentityZoneProvisioning zoneProvisioning,
-                                               @Value("${uaa.dashboard.uri}") String uaaDashboardUri) {
-        return new OrchestratorZoneService(zoneProvisioning, uaaDashboardUri);
+    public OrchestratorZoneService orchestratorZoneService(IdentityZoneProvisioning zoneProvisioning,
+                                                           @Qualifier("identityProviderProvisioning") IdentityProviderProvisioning idpProvisioning,
+                                                           @Qualifier("scimGroupProvisioning") ScimGroupProvisioning groupProvisioning,
+                                                           @Qualifier("clientDetailsService") QueryableResourceManager<ClientDetails> clientDetailsService,
+                                                           @Qualifier("clientDetailsValidator") ClientDetailsValidator clientDetailsValidator,
+                                                           @Value("${uaa.dashboard.uri}") String uaaDashboardUri,
+                                                           @Value("${issuer.uri}") String uaaUrl) {
+        return new OrchestratorZoneService(zoneProvisioning, idpProvisioning, groupProvisioning, clientDetailsService,
+                                           clientDetailsValidator, uaaDashboardUri, uaaUrl);
     }
 
 }

--- a/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/OrchestratorZoneService.java
+++ b/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/OrchestratorZoneService.java
@@ -1,26 +1,84 @@
 package org.cloudfoundry.identity.uaa.zone;
 
+import static java.util.Optional.ofNullable;
+import static org.springframework.util.StringUtils.hasLength;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.math.BigInteger;
+import java.net.URI;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.X509v1CertificateBuilder;
+import org.bouncycastle.openssl.PEMEncryptor;
+import org.bouncycastle.openssl.jcajce.JcaMiscPEMGenerator;
+import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
+import org.bouncycastle.openssl.jcajce.JcePEMEncryptorBuilder;
+import org.bouncycastle.operator.OperatorCreationException;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+
 import static org.springframework.http.HttpStatus.ACCEPTED;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 
-import java.net.URI;
+import org.cloudfoundry.identity.uaa.client.ClientDetailsValidator;
+import org.cloudfoundry.identity.uaa.client.ClientDetailsValidator.Mode;
+import org.cloudfoundry.identity.uaa.constants.OriginKeys;
+import org.cloudfoundry.identity.uaa.provider.IdentityProvider;
+import org.cloudfoundry.identity.uaa.provider.IdentityProviderProvisioning;
+import org.cloudfoundry.identity.uaa.provider.UaaIdentityProviderDefinition;
+import org.cloudfoundry.identity.uaa.resources.QueryableResourceManager;
+import org.cloudfoundry.identity.uaa.saml.SamlKey;
+import org.cloudfoundry.identity.uaa.scim.ScimGroup;
+import org.cloudfoundry.identity.uaa.scim.ScimGroupProvisioning;
+import org.cloudfoundry.identity.uaa.util.JsonUtils;
 
 import org.cloudfoundry.identity.uaa.audit.event.EntityDeletedEvent;
 import org.cloudfoundry.identity.uaa.zone.model.ConnectionDetails;
 import org.cloudfoundry.identity.uaa.zone.model.OrchestratorZone;
 import org.cloudfoundry.identity.uaa.zone.model.OrchestratorZoneHeader;
 import org.cloudfoundry.identity.uaa.zone.model.OrchestratorZoneResponse;
+import org.cloudfoundry.identity.uaa.zone.model.OrchestratorZoneRequest;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.oauth2.common.util.RandomValueStringGenerator;
+import org.springframework.security.oauth2.provider.ClientDetails;
+import org.springframework.security.oauth2.provider.client.BaseClientDetails;
+import org.springframework.util.StringUtils;
+
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 public class OrchestratorZoneService implements ApplicationEventPublisherAware {
 
     public static final String X_IDENTITY_ZONE_ID = "X-Identity-Zone-Id";
+    public static final String GENERATED_KEY_ID = "generated-saml-key";
+    private static final String SUBDOMAIN_REGEX = "(?:[A-Za-z0-9][A-Za-z0-9\\-]{0,61}[A-Za-z0-9]|[A-Za-z0-9])";
+    private static final Pattern SUBDOMAIN_PATTERN;
+    public static final String UAA_CUSTOM_SUBDOMAIN = "subdomain";
+    public static final String UAA_ADMIN_SECRET = "adminClientSecret";
+    public static final String BEGIN_CERT = "-----BEGIN CERTIFICATE-----";
+    public static final String END_CERT = "-----END CERTIFICATE-----";
+
     public static final String CLIENT_ID = "admin";
     public static final String ZONE_AUTHORITIES =
         "clients.admin,clients.read,clients.write,clients.secret,idps.read,idps.write,sps" +
@@ -28,27 +86,47 @@ public class OrchestratorZoneService implements ApplicationEventPublisherAware {
     public static final String GRANT_TYPES = "client_credentials";
     public static final String RESOURCE_IDS = "none";
     public static final String SCOPES = "uaa.none";
-    public static final String GENERATED_KEY_ID = "generated-saml-key";
 
     private static final java.util.Base64.Encoder base64encoder = java.util.Base64.getMimeEncoder(64, "\n".getBytes());
 
     private final IdentityZoneProvisioning zoneProvisioning;
+    private final IdentityProviderProvisioning idpProvisioning;
+    private final ScimGroupProvisioning groupProvisioning;
+    private final QueryableResourceManager<ClientDetails> clientDetailsService;
+    private final ClientDetailsValidator clientDetailsValidator;
     private final String uaaDashboardUri;
+    private final String domainName;
+
+    static {
+        SUBDOMAIN_PATTERN = Pattern.compile(SUBDOMAIN_REGEX);
+    }
+
     private ApplicationEventPublisher publisher;
 
     private static final Logger logger = LoggerFactory.getLogger(OrchestratorZoneService.class);
 
     public OrchestratorZoneService(IdentityZoneProvisioning zoneProvisioning,
-                                   String uaaDashboardUri) {
+                                   IdentityProviderProvisioning idpProvisioning,
+                                   ScimGroupProvisioning groupProvisioning,
+                                   QueryableResourceManager<ClientDetails> clientDetailsService,
+                                   ClientDetailsValidator clientDetailsValidator,
+                                   String uaaDashboardUri, String uaaUrl
+                                  ) {
         this.zoneProvisioning = zoneProvisioning;
+        this.idpProvisioning = idpProvisioning;
+        this.groupProvisioning = groupProvisioning;
+        this.clientDetailsService = clientDetailsService;
+        this.clientDetailsValidator = clientDetailsValidator;
         this.uaaDashboardUri = uaaDashboardUri;
+        this.domainName = uaaUrl;
     }
 
     public OrchestratorZoneResponse getZoneDetails(String zoneName) {
         IdentityZone identityZone = zoneProvisioning.retrieveByName(zoneName);
-        OrchestratorZone zone = new OrchestratorZone(null, identityZone.getSubdomain());
+        OrchestratorZone zone = new OrchestratorZone(null, getSubDomainStr(identityZone));
         String uaaUri = ServletUriComponentsBuilder.fromCurrentContextPath().toUriString();
-        String zoneUri = getZoneUri(identityZone.getSubdomain(), uaaUri);
+        String subDomain = identityZone.getSubdomain();
+        String zoneUri = getZoneUri(subDomain, uaaUri);
         ConnectionDetails connectionDetails = buildConnectionDetails(zoneName, identityZone, zoneUri);
         return new OrchestratorZoneResponse(zoneName, zone, connectionDetails);
     }
@@ -88,13 +166,319 @@ public class OrchestratorZoneService implements ApplicationEventPublisherAware {
     private String getZoneUri(String subdomain, String uaaUri) {
         URI uaaUriObject = URI.create(uaaUri);
         String currentUAAHostName = uaaUriObject.getHost();
+        String replacement = subdomain + "." + currentUAAHostName;
+        if (!hasLength(subdomain)) {
+            replacement = currentUAAHostName;
+        };
         URI newUAARoute = URI
-            .create(uaaUriObject.toString().replace(currentUAAHostName, subdomain + "." + currentUAAHostName));
+            .create(uaaUriObject.toString().replace(currentUAAHostName, replacement));
         return newUAARoute.toString();
     }
 
     @Override
     public void setApplicationEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
         this.publisher = applicationEventPublisher;
+    }
+
+    private String getSubDomainStr(IdentityZone identityZone) {
+        String id = identityZone.getId();
+        String subDomain = identityZone.getSubdomain();
+        if(id.equals(subDomain)){
+            subDomain = null;
+        }
+        return subDomain;
+    }
+
+    public void createZone(OrchestratorZoneRequest zoneRequest) throws OrchestratorZoneServiceException,
+                                                                       ZoneAlreadyExistsException,
+                                                                       AccessDeniedException,
+                                                                       IOException {
+        if (!IdentityZoneHolder.isUaa()) {
+            throw new AccessDeniedException("Zones can only be created by being authenticated in the default zone.");
+        }
+        String name = zoneRequest.getName();
+        String adminClientSecret = getAdminClientSecret(zoneRequest);
+
+        checkOrchestratorZoneExists(name);
+
+        String subdomain = zoneRequest.getParameters().getSubdomain();
+        String id = UUID.randomUUID().toString();
+        subdomain = getSubDomain(subdomain, id);
+
+        String zoneSigningKey = createSigningKey(name);
+
+        IdentityZone identityZone = generateIdentityZone(subdomain, name, id, zoneSigningKey);
+
+        IdentityZone previous = IdentityZoneHolder.get();
+        try {
+            IdentityZone created = createIdentityZone(identityZone);
+            IdentityZoneHolder.set(created);
+            createDefaultIdp(created);
+            createUserGroups(created);
+            createZoneAdminClient(adminClientSecret, created);
+        } finally {
+            IdentityZoneHolder.set(previous);
+        }
+    }
+
+    private String getAdminClientSecret(OrchestratorZoneRequest zoneRequest) throws OrchestratorZoneServiceException {
+        String adminClientSecret = zoneRequest.getParameters().getAdminClientSecret();
+        if (!StringUtils.hasText(adminClientSecret)) {
+            throw new OrchestratorZoneServiceException(
+                "The \"" + UAA_ADMIN_SECRET + "\" field cannot contain spaces or cannot be blank.");
+        }
+        return adminClientSecret;
+    }
+
+    private String getSubDomain(String subdomain, String id) throws OrchestratorZoneServiceException {
+        String customSubdomain = getCustomSubdomain(subdomain);
+        if (customSubdomain == null) {
+            subdomain = id;
+        } else {
+            subdomain = customSubdomain;
+        }
+        return subdomain;
+    }
+
+    private void checkOrchestratorZoneExists(String name) throws ZoneAlreadyExistsException {
+        IdentityZone identityZone = null;
+        try{
+            identityZone = zoneProvisioning.retrieveByName(name);
+            if(identityZone != null){
+                throw new ZoneAlreadyExistsException("Orchestrator zone already exists for name:  " + name );
+            }
+        } catch (ZoneDoesNotExistsException e){
+            String message = String.format("Its okey! Zone with name %s does not exists ", name);
+            logger.debug(message, e);
+        }
+    }
+
+    private void createZoneAdminClient(String adminClientSecret, IdentityZone created)
+        throws OrchestratorZoneServiceException {
+        String zoneId = IdentityZoneHolder.get().getId();
+        String authorities = ZONE_AUTHORITIES + ",zones." + zoneId + ".admin";
+        try {
+            createZoneAdminClient(created.getId(), authorities, CLIENT_ID, adminClientSecret, GRANT_TYPES, RESOURCE_IDS,
+                                  SCOPES);
+        } catch (Exception e) {
+            String errorMessage = String.format("Unable to create client for zone name : %s  failed.", created.getName());
+            logger.error(errorMessage, e);
+            throw new OrchestratorZoneServiceException(errorMessage+" Exception is :" + e.getMessage());
+        }
+    }
+
+    private void createDefaultIdp(IdentityZone created) throws OrchestratorZoneServiceException {
+        try {
+            IdentityProvider defaultIdp = new IdentityProvider();
+            defaultIdp.setName(OriginKeys.UAA);
+            defaultIdp.setType(OriginKeys.UAA);
+            defaultIdp.setOriginKey(OriginKeys.UAA);
+            defaultIdp.setIdentityZoneId(created.getId());
+            UaaIdentityProviderDefinition idpDefinition = new UaaIdentityProviderDefinition();
+            idpDefinition.setPasswordPolicy(null);
+            defaultIdp.setConfig(idpDefinition);
+            idpProvisioning.create(defaultIdp, created.getId());
+            logger.debug("Created default IDP in zone - created zone name [" + created.getName() + "]");
+        } catch (Exception e) {
+            String errorMessage = String.format(
+                "Unable to create identity provider for zone name : %s",
+                created.getName());
+            logger.error(errorMessage, e);
+            throw new OrchestratorZoneServiceException(errorMessage + " Exception is : " + e.getMessage());
+        }
+    }
+
+    private IdentityZone createIdentityZone(IdentityZone identityZone)
+        throws OrchestratorZoneServiceException {
+        IdentityZone created = null;
+        try {
+            logger.debug("Zone - creating zone name [" + identityZone.getName() + "]");
+            created = zoneProvisioning.create(identityZone);
+            logger.debug("Zone - created zone name [" + identityZone.getName() + "]");
+        } catch (Exception e) {
+            String errorMessage = String.format("Unable to create identity zone for zone name : %s", identityZone.getName());
+            logger.error(errorMessage, e);
+            throw new OrchestratorZoneServiceException(errorMessage+ " Exception is : " + e.getMessage());
+        }
+        return created;
+    }
+
+    private IdentityZone generateIdentityZone(String subdomain, String name, String id, String zoneSigningKey) throws OrchestratorZoneServiceException {
+        IdentityZone identityZone = new IdentityZone();
+        identityZone.setId(id);
+        identityZone.setName(name);
+        identityZone.setSubdomain(subdomain);
+        setTokenPolicy(zoneSigningKey, identityZone);
+        setSamlConfig(identityZone);
+        identityZone.getConfig().getLinks().getLogout().setWhitelist(createDeploymentSpecificLogoutWhiteList());
+        return identityZone;
+    }
+
+    private void setSamlConfig(IdentityZone identityZone) throws OrchestratorZoneServiceException {
+        try {
+            identityZone.getConfig().setSamlConfig(createSamlConfig(identityZone.getSubdomain()));
+        } catch (Exception e) {
+            String errorMessage = String.format(
+                "Unexpected exception while create saml config for zone name: %s",
+                identityZone.getName());
+            logger.error(errorMessage, e);
+            throw new OrchestratorZoneServiceException(errorMessage+ " Exception is : " + e.getMessage());
+        }
+    }
+
+    private void setTokenPolicy(String zoneSigningKey, IdentityZone identityZone) {
+        String activeKeyId = new RandomValueStringGenerator(5).generate();
+        Map<String, String> keys = getKeys(zoneSigningKey, activeKeyId);
+        TokenPolicy tokenPolicy = new TokenPolicy();
+        tokenPolicy.setActiveKeyId(activeKeyId);
+        tokenPolicy.setKeys(keys);
+        identityZone.getConfig().setTokenPolicy(tokenPolicy);
+    }
+
+    private String createSigningKey(String zoneName) throws OrchestratorZoneServiceException, IOException {
+        StringWriter pemStringWriter = new StringWriter();
+        JcaPEMWriter pemWriter = new JcaPEMWriter(pemStringWriter);
+        try {
+            KeyPairGenerator keyPairGenerator = null;
+            keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+            keyPairGenerator.initialize(2048);
+            pemWriter.writeObject(keyPairGenerator.genKeyPair().getPrivate());
+        } catch (Exception e) {
+            logAndThowException(zoneName, e);
+        } finally {
+            pemWriter.flush();
+            pemWriter.close();
+        }
+        return pemStringWriter.toString();
+    }
+
+    private void logAndThowException(String zoneName, Exception e) throws OrchestratorZoneServiceException {
+        String errorMessage = String.format(
+            "Unexpected exception while create signingKey for zone name : %s",
+            zoneName);
+        logger.error(errorMessage, e);
+        throw new OrchestratorZoneServiceException(errorMessage + " Exception is : " + e.getMessage());
+    }
+
+    private String getCustomSubdomain(final String subdomain) throws OrchestratorZoneServiceException {
+        if (subdomain == null) {
+            return null;
+        }
+        String subDomain = subdomain;
+        if (!StringUtils.hasText(subDomain)) {
+            throw new OrchestratorZoneServiceException(
+                "The \"" + UAA_CUSTOM_SUBDOMAIN + "\" field cannot contain spaces or cannot be blank.");
+        }
+        if (!SUBDOMAIN_PATTERN.matcher(subDomain).matches()) {
+            throw new OrchestratorZoneServiceException("The \"" + UAA_CUSTOM_SUBDOMAIN
+                                                       + "\" is invalid. Special characters are not allowed in the subdomain name except hyphen which can be specified in the middle.");
+        }
+        return subDomain;
+    }
+
+    private void createZoneAdminClient(final String id, final String authorities, final String clientId,
+                                       final String clientSecret,
+                                       final String grantTypes, final String resourceIds, final String scopes) {
+        BaseClientDetails clientDetails = new BaseClientDetails(clientId, resourceIds, scopes, grantTypes, authorities);
+        clientDetails.setClientSecret(clientSecret);
+        ClientDetails details = clientDetailsValidator.validate(clientDetails, Mode.CREATE);
+        clientDetailsService.create(details, id);
+    }
+
+    private void createUserGroups(IdentityZone zone) {
+        UserConfig userConfig = zone.getConfig().getUserConfig();
+        if (userConfig != null) {
+            List<String> defaultGroups = ofNullable(userConfig.getDefaultGroups()).orElse(Collections.emptyList());
+            logger.debug(String.format("About to create default groups count: %s for zone name: %s",
+                                       defaultGroups.size(), zone.getName()));
+            for (String group : defaultGroups) {
+                logger.debug(String.format("Creating zone default group: %s for zone name: %s", group,
+                                           zone.getName()));
+                groupProvisioning.createOrGet(
+                    new ScimGroup(
+                        null,
+                        group,
+                        zone.getId()
+                    ),
+                    zone.getId()
+                                             );
+            }
+        }
+    }
+
+    private List<String>  createDeploymentSpecificLogoutWhiteList()
+    {
+        String runDomainFQDN = getRunDomainFromUAADomain();
+        return (!hasLength(runDomainFQDN))  ? Collections.singletonList("http*://**") :
+               Collections.singletonList("http*://**" + runDomainFQDN);
+    }
+
+    /**
+     * Remove all characters till first dot
+     */
+    private String getRunDomainFromUAADomain() {
+        if (!hasLength(domainName))  return domainName;
+        int firstDotIndex = domainName.indexOf('.');
+        if (firstDotIndex == -1)  return "";
+        return domainName.substring(firstDotIndex);
+    }
+
+
+    private Map<String, String> getKeys(String zoneSigningKey, String activeKeyId) {
+        Map<String, String> keysMap = new HashMap<>();
+        Map<String, Map<String, String>> keys = new HashMap<>();
+        Map<String, String> signingKeyMap = new HashMap<>();
+        signingKeyMap.put("signingKey", zoneSigningKey);
+        String keysStr = JsonUtils.writeValueAsString(signingKeyMap);
+        keysMap.put(activeKeyId, keysStr);
+        return keysMap;
+    }
+
+    private SamlConfig createSamlConfig(String subdomain) throws IOException, NoSuchAlgorithmException, OperatorCreationException {
+        StringWriter pemStringWriter = new StringWriter();
+        JcaPEMWriter pemWriter = new JcaPEMWriter(pemStringWriter);
+        SamlConfig samlConfig = new SamlConfig();
+        try {
+            JcePEMEncryptorBuilder builder = new JcePEMEncryptorBuilder("DES-EDE3-CBC");
+            builder.setProvider("BC");
+            String passphrase = new RandomValueStringGenerator(8).generate();
+            PEMEncryptor pemEncryptor = builder.build(passphrase.toCharArray());
+            KeyPairGenerator rsa = KeyPairGenerator.getInstance("RSA");
+            rsa.initialize(2048);
+            KeyPair kp = rsa.generateKeyPair();
+
+            JcaMiscPEMGenerator pemGenerator = new JcaMiscPEMGenerator(kp.getPrivate(), pemEncryptor);
+            pemWriter.writeObject(pemGenerator);
+            pemWriter.flush();
+
+            Calendar cal = Calendar.getInstance();
+            cal.add(Calendar.YEAR, 10);
+
+            byte[] pk = kp.getPublic().getEncoded();
+            SubjectPublicKeyInfo bcPk = SubjectPublicKeyInfo.getInstance(pk);
+            String dn = "C=US, ST=CA, L=San Ramon, O=GE, OU=GE Digital, CN=PredixUAA"+subdomain;
+            X509v1CertificateBuilder certGen = new X509v1CertificateBuilder(
+                new X500Name(dn),
+                BigInteger.ONE,
+                new Date(),
+                cal.getTime(),
+                new X500Name(dn),
+                bcPk
+            );
+            X509CertificateHolder certHolder = certGen
+                .build(new JcaContentSignerBuilder("SHA256withRSA").build(kp.getPrivate()));
+
+            HashMap<String, SamlKey> samlKeys = new HashMap<>();
+
+            String certificate = BEGIN_CERT + "\n" + Arrays.toString(base64encoder.encode(certHolder.getEncoded())) + "\n" + END_CERT;
+
+            samlKeys.put(GENERATED_KEY_ID, new SamlKey(pemStringWriter.toString(), passphrase, certificate));
+            samlConfig.setKeys(samlKeys);
+            samlConfig.setActiveKeyId(GENERATED_KEY_ID);
+        } finally {
+            pemWriter.flush();
+            pemWriter.close();
+        }
+        return samlConfig;
     }
 }

--- a/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/OrchestratorZoneServiceException.java
+++ b/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/OrchestratorZoneServiceException.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ *     Cloud Foundry
+ *     Copyright (c) [2009-2016] Pivotal Software, Inc. All Rights Reserved.
+ *
+ *     This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ *     You may not use this product except in compliance with the License.
+ *
+ *     This product includes a number of subcomponents with
+ *     separate copyright notices and license terms. Your use of these
+ *     subcomponents is subject to the terms and conditions of the
+ *     subcomponent's license, as noted in the LICENSE file.
+ *******************************************************************************/
+package org.cloudfoundry.identity.uaa.zone;
+
+public class OrchestratorZoneServiceException extends Exception {
+
+    public OrchestratorZoneServiceException(String message) {
+        super(message);
+    }
+
+    public OrchestratorZoneServiceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public OrchestratorZoneServiceException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/model/OrchestratorZone.java
+++ b/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/model/OrchestratorZone.java
@@ -12,5 +12,5 @@ import lombok.NoArgsConstructor;
 @JsonInclude(Include.NON_NULL)
 public class OrchestratorZone {
     private String adminClientSecret;
-    private String subdomain;
+    private String subdomain = null;
 }

--- a/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/model/OrchestratorZoneRequest.java
+++ b/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/model/OrchestratorZoneRequest.java
@@ -1,9 +1,11 @@
 package org.cloudfoundry.identity.uaa.zone.model;
 
 import lombok.Data;
+import javax.validation.constraints.NotBlank;
 
 @Data
 public class OrchestratorZoneRequest {
+    @NotBlank(message = org.cloudfoundry.identity.uaa.zone.OrchestratorZoneController.MANDATORY_VALIDATION_MESSAGE)
     private String name;
     private OrchestratorZone parameters;
 }

--- a/zone-service/src/test/java/org/cloudfoundry/identity/uaa/zone/OrchestratorZoneServiceTests.java
+++ b/zone-service/src/test/java/org/cloudfoundry/identity/uaa/zone/OrchestratorZoneServiceTests.java
@@ -3,37 +3,126 @@ package org.cloudfoundry.identity.uaa.zone;
 import static org.cloudfoundry.identity.uaa.zone.OrchestratorZoneService.X_IDENTITY_ZONE_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.security.Security;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Stream;
+
 import net.bytebuddy.utility.RandomString;
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.cloudfoundry.identity.uaa.client.ClientDetailsValidator;
+import org.cloudfoundry.identity.uaa.constants.OriginKeys;
+import org.cloudfoundry.identity.uaa.provider.IdentityProvider;
+import org.cloudfoundry.identity.uaa.provider.IdentityProviderProvisioning;
+import org.cloudfoundry.identity.uaa.provider.UaaIdentityProviderDefinition;
+import org.cloudfoundry.identity.uaa.resources.QueryableResourceManager;
+import org.cloudfoundry.identity.uaa.scim.ScimGroupProvisioning;
+import org.cloudfoundry.identity.uaa.zone.model.OrchestratorZone;
+import org.cloudfoundry.identity.uaa.zone.model.OrchestratorZoneRequest;
 import org.cloudfoundry.identity.uaa.zone.model.OrchestratorZoneResponse;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.oauth2.provider.ClientDetails;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
 public class OrchestratorZoneServiceTests {
 
     public static final String ZONE_NAME = "The Twiglet Zone";
+    public static final String SUB_DOMAIN_NAME = "sub-domain-01";
+    public static final String SUB_DOMAIN_BLANK_SPACE = " ";
+    public static final String UAA_DASHBOARD_URI = "http://localhost/dashboard";
+    public static final String DOMAIN_NAME = "domain-name";
+    public static final String ADMIN_CLIENT_SECRET = "admin-secret-01";
+    public static final String ADMIN_CLIENT_SECRET_EMPTY = "";
     private OrchestratorZoneService zoneService;
     private IdentityZoneProvisioning zoneProvisioning;
+    private IdentityProviderProvisioning idpProvisioning;
+    private ScimGroupProvisioning groupProvisioning;
+    private QueryableResourceManager<ClientDetails> clientDetailsService;
+    private ClientDetailsValidator clientDetailsValidator;
+
+    private final String serviceProviderKey =
+        "-----BEGIN RSA PRIVATE KEY-----\n" +
+        "MIICXQIBAAKBgQDHtC5gUXxBKpEqZTLkNvFwNGnNIkggNOwOQVNbpO0WVHIivig5\n" +
+        "L39WqS9u0hnA+O7MCA/KlrAR4bXaeVVhwfUPYBKIpaaTWFQR5cTR1UFZJL/OF9vA\n" +
+        "fpOwznoD66DDCnQVpbCjtDYWX+x6imxn8HCYxhMol6ZnTbSsFW6VZjFMjQIDAQAB\n" +
+        "AoGAVOj2Yvuigi6wJD99AO2fgF64sYCm/BKkX3dFEw0vxTPIh58kiRP554Xt5ges\n" +
+        "7ZCqL9QpqrChUikO4kJ+nB8Uq2AvaZHbpCEUmbip06IlgdA440o0r0CPo1mgNxGu\n" +
+        "lhiWRN43Lruzfh9qKPhleg2dvyFGQxy5Gk6KW/t8IS4x4r0CQQD/dceBA+Ndj3Xp\n" +
+        "ubHfxqNz4GTOxndc/AXAowPGpge2zpgIc7f50t8OHhG6XhsfJ0wyQEEvodDhZPYX\n" +
+        "kKBnXNHzAkEAyCA76vAwuxqAd3MObhiebniAU3SnPf2u4fdL1EOm92dyFs1JxyyL\n" +
+        "gu/DsjPjx6tRtn4YAalxCzmAMXFSb1qHfwJBAM3qx3z0gGKbUEWtPHcP7BNsrnWK\n" +
+        "vw6By7VC8bk/ffpaP2yYspS66Le9fzbFwoDzMVVUO/dELVZyBnhqSRHoXQcCQQCe\n" +
+        "A2WL8S5o7Vn19rC0GVgu3ZJlUrwiZEVLQdlrticFPXaFrn3Md82ICww3jmURaKHS\n" +
+        "N+l4lnMda79eSp3OMmq9AkA0p79BvYsLshUJJnvbk76pCjR28PK4dV1gSDUEqQMB\n" +
+        "qy45ptdwJLqLJCeNoR0JUcDNIRhOCuOPND7pcMtX6hI/\n" +
+        "-----END RSA PRIVATE KEY-----";
+
+    private final String serviceProviderKeyPassword = "password";
+
+    private final String serviceProviderCertificate =
+        "-----BEGIN CERTIFICATE-----\n" +
+        "MIIDSTCCArKgAwIBAgIBADANBgkqhkiG9w0BAQQFADB8MQswCQYDVQQGEwJhdzEO\n" +
+        "MAwGA1UECBMFYXJ1YmExDjAMBgNVBAoTBWFydWJhMQ4wDAYDVQQHEwVhcnViYTEO\n" +
+        "MAwGA1UECxMFYXJ1YmExDjAMBgNVBAMTBWFydWJhMR0wGwYJKoZIhvcNAQkBFg5h\n" +
+        "cnViYUBhcnViYS5hcjAeFw0xNTExMjAyMjI2MjdaFw0xNjExMTkyMjI2MjdaMHwx\n" +
+        "CzAJBgNVBAYTAmF3MQ4wDAYDVQQIEwVhcnViYTEOMAwGA1UEChMFYXJ1YmExDjAM\n" +
+        "BgNVBAcTBWFydWJhMQ4wDAYDVQQLEwVhcnViYTEOMAwGA1UEAxMFYXJ1YmExHTAb\n" +
+        "BgkqhkiG9w0BCQEWDmFydWJhQGFydWJhLmFyMIGfMA0GCSqGSIb3DQEBAQUAA4GN\n" +
+        "ADCBiQKBgQDHtC5gUXxBKpEqZTLkNvFwNGnNIkggNOwOQVNbpO0WVHIivig5L39W\n" +
+        "qS9u0hnA+O7MCA/KlrAR4bXaeVVhwfUPYBKIpaaTWFQR5cTR1UFZJL/OF9vAfpOw\n" +
+        "znoD66DDCnQVpbCjtDYWX+x6imxn8HCYxhMol6ZnTbSsFW6VZjFMjQIDAQABo4Ha\n" +
+        "MIHXMB0GA1UdDgQWBBTx0lDzjH/iOBnOSQaSEWQLx1syGDCBpwYDVR0jBIGfMIGc\n" +
+        "gBTx0lDzjH/iOBnOSQaSEWQLx1syGKGBgKR+MHwxCzAJBgNVBAYTAmF3MQ4wDAYD\n" +
+        "VQQIEwVhcnViYTEOMAwGA1UEChMFYXJ1YmExDjAMBgNVBAcTBWFydWJhMQ4wDAYD\n" +
+        "VQQLEwVhcnViYTEOMAwGA1UEAxMFYXJ1YmExHTAbBgkqhkiG9w0BCQEWDmFydWJh\n" +
+        "QGFydWJhLmFyggEAMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEEBQADgYEAYvBJ\n" +
+        "0HOZbbHClXmGUjGs+GS+xC1FO/am2suCSYqNB9dyMXfOWiJ1+TLJk+o/YZt8vuxC\n" +
+        "KdcZYgl4l/L6PxJ982SRhc83ZW2dkAZI4M0/Ud3oePe84k8jm3A7EvH5wi5hvCkK\n" +
+        "RpuRBwn3Ei+jCRouxTbzKPsuCVB+1sNyxMTXzf0=\n" +
+        "-----END CERTIFICATE-----\n";
+
+
+    private IdentityZone mockIdentityZone;
 
     @BeforeEach
     public void beforeEachTest() {
-        zoneProvisioning = Mockito.mock(IdentityZoneProvisioning.class);
-        zoneService = new OrchestratorZoneService(zoneProvisioning, "http://localhost/dashboard");
-        zoneService.setApplicationEventPublisher(mock(ApplicationEventPublisher.class));
+        mockIdentityZone = mock(IdentityZone.class);
+        zoneProvisioning = mock(IdentityZoneProvisioning.class);
+        idpProvisioning = mock(IdentityProviderProvisioning.class);
+        groupProvisioning = mock(ScimGroupProvisioning.class);
+        clientDetailsService = mock(QueryableResourceManager.class);
+        clientDetailsValidator = mock(ClientDetailsValidator.class);
+        zoneService = new OrchestratorZoneService(zoneProvisioning, idpProvisioning, groupProvisioning,
+                                                  clientDetailsService, clientDetailsValidator,
+                                                  UAA_DASHBOARD_URI, DOMAIN_NAME);
         MockHttpServletRequest request = new MockHttpServletRequest();
         RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+        IdentityZoneHolder.set(IdentityZone.getUaa());
     }
 
     @Test
@@ -90,10 +179,142 @@ public class OrchestratorZoneServiceTests {
 
     private IdentityZone buildIdentityZone() {
         IdentityZone identityZone = new IdentityZone();
-        identityZone.setId(RandomString.make(10));
-        identityZone.setSubdomain(RandomString.make(10).toLowerCase());
+        String id = UUID.randomUUID().toString();
+        identityZone.setId(id);
+        identityZone.setSubdomain(SUB_DOMAIN_NAME);
         identityZone.setName(ZONE_NAME);
         identityZone.setDescription("Like the Twilight Zone but tastier.");
         return identityZone;
+    }
+
+    @Test
+    public void testCreateZone() throws OrchestratorZoneServiceException {
+        Security.addProvider(new BouncyCastleProvider());
+        OrchestratorZoneRequest zoneRequest =  getOrchestratorZoneRequest(ZONE_NAME, ADMIN_CLIENT_SECRET,
+                                                                          SUB_DOMAIN_NAME);
+        IdentityZone identityZone = createIdentityZone();
+        IdentityProvider identityProvider = createDefaultIdp(identityZone);
+        when(zoneProvisioning.create(any())).thenReturn(identityZone);
+        when(idpProvisioning.create(any(),any())).thenReturn(identityProvider);
+        when(clientDetailsService.retrieve(any(),any())).thenReturn(any());
+        zoneService.createZone(zoneRequest);
+        verify(zoneProvisioning, times(1)).retrieveByName(any());
+        verify(zoneProvisioning, times(1)).create(any());
+        verify(idpProvisioning, times(1)).create(any(),any());
+        verify(clientDetailsService, times(1)).create(any(),any());
+        verify(clientDetailsValidator, times(1)).validate(any(),any());
+    }
+
+    @Test
+    public void testCreateZoneDetails_AccessDeniedException() {
+        when(mockIdentityZone.getId()).thenReturn("not uaa");
+        IdentityZoneHolder.set(mockIdentityZone);
+        OrchestratorZoneRequest zoneRequest =  getOrchestratorZoneRequest(ZONE_NAME, ADMIN_CLIENT_SECRET,
+                                                                          SUB_DOMAIN_NAME);
+        AccessDeniedException exception =
+            assertThrows(AccessDeniedException.class, () ->
+                             zoneService.createZone(zoneRequest),
+                         "Zones can only be created by being " +
+                         "authenticated in the default zone.");
+        assertTrue(exception.getMessage().contains("Zones can only be created by being " +
+                                                   "authenticated in the default zone."));
+    }
+
+    @Test
+    public void testCreateZone_AdminClientSecretEmptyFailWithException() {
+        OrchestratorZoneRequest zoneRequest = getOrchestratorZoneRequest(ZONE_NAME, ADMIN_CLIENT_SECRET_EMPTY, SUB_DOMAIN_NAME);
+        assertEmptyInputThrowException(zoneRequest);
+    }
+
+    private void assertEmptyInputThrowException(OrchestratorZoneRequest zoneRequest) {
+        OrchestratorZoneServiceException exception =
+            assertThrows(OrchestratorZoneServiceException.class, () ->
+                             zoneService.createZone(zoneRequest),
+                         "field cannot contain spaces or cannot be blank.");
+        assertTrue(exception.getMessage().contains("field cannot contain spaces or cannot be blank."));
+    }
+
+    @Test
+    public void testCreateZone_SubDomainWithBlankFailWithException() {
+        OrchestratorZoneRequest zoneRequest = getOrchestratorZoneRequest(ZONE_NAME, ADMIN_CLIENT_SECRET,
+                                                                         SUB_DOMAIN_BLANK_SPACE);
+        assertEmptyInputThrowException(zoneRequest);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SubDomainWithSpaceOrSpecialCharArguments.class)
+    public void testCreateZone_SubDomainWithSpaceOrSpecialCharFailWithException(String subDomain) {
+        OrchestratorZoneRequest zoneRequest = getOrchestratorZoneRequest(ZONE_NAME, ADMIN_CLIENT_SECRET,
+                                                                         subDomain);
+
+        OrchestratorZoneServiceException exception =
+            assertThrows(OrchestratorZoneServiceException.class, () ->
+                             zoneService.createZone(zoneRequest),
+                         "Special characters are not allowed in the subdomain name except hyphen which can be specified in the middle.");
+        assertTrue(exception.getMessage().contains("Special characters are not allowed in the subdomain name except hyphen which can be specified in the middle."));
+    }
+
+    @Test
+    public void testCreateZone_checkOrchestratorZoneExists() {
+        OrchestratorZoneRequest zoneRequest = getOrchestratorZoneRequest(ZONE_NAME, ADMIN_CLIENT_SECRET,
+                                                                         SUB_DOMAIN_NAME);
+        when(zoneProvisioning.retrieveByName(any())).thenReturn(new IdentityZone());
+        ZoneAlreadyExistsException exception =
+            assertThrows(ZoneAlreadyExistsException.class, () ->
+                             zoneService.createZone(zoneRequest),
+                         "Orchestrator zone already exists for name");
+        assertTrue(exception.getMessage().contains("Orchestrator zone already exists for name"));
+    }
+
+    private static class SubDomainWithSpaceOrSpecialCharArguments implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            return Stream.of(
+                Arguments.of("sub#-domain"),
+                Arguments.of("-subdomainStartsWithHYphen"),
+                Arguments.of("subdomainEndsWithHYphen-"),
+                Arguments.of("sub\\\\domaincontainsslash"),
+                Arguments.of("sub$%domaincontainsSpecialChars")
+                            );
+        }
+    }
+
+    private OrchestratorZoneRequest getOrchestratorZoneRequest(String name, String adminClientSecret,
+                                                               String subDomain) {
+        OrchestratorZoneRequest zoneRequest = new OrchestratorZoneRequest();
+        OrchestratorZone zone = new OrchestratorZone(adminClientSecret, subDomain);
+        zoneRequest.setName(name);
+        zoneRequest.setParameters(zone);
+        return zoneRequest;
+    }
+
+    private IdentityZone createIdentityZone() {
+        IdentityZone identityZone = buildIdentityZone();
+        IdentityZoneConfiguration identityZoneConfiguration = new IdentityZoneConfiguration();
+        Map<String, String> keys = new HashMap<>();
+        keys.put("kid", "key");
+        identityZoneConfiguration.getTokenPolicy().setKeys(keys);
+        identityZoneConfiguration.getTokenPolicy().setActiveKeyId("kid");
+        identityZoneConfiguration.getTokenPolicy().setKeys(keys);
+
+        identityZone.setConfig(identityZoneConfiguration);
+        identityZone.getConfig().getSamlConfig().setPrivateKey(serviceProviderKey);
+        identityZone.getConfig().getSamlConfig().setPrivateKeyPassword(serviceProviderKeyPassword);
+        identityZone.getConfig().getSamlConfig().setCertificate(serviceProviderCertificate);
+
+        return identityZone;
+    }
+
+    private IdentityProvider createDefaultIdp(IdentityZone created) {
+        IdentityProvider defaultIdp = new IdentityProvider();
+        defaultIdp.setName(OriginKeys.UAA);
+        defaultIdp.setType(OriginKeys.UAA);
+        defaultIdp.setOriginKey(OriginKeys.UAA);
+        defaultIdp.setIdentityZoneId(created.getId());
+        UaaIdentityProviderDefinition idpDefinition = new UaaIdentityProviderDefinition();
+        idpDefinition.setPasswordPolicy(null);
+        defaultIdp.setConfig(idpDefinition);
+        return defaultIdp;
     }
 }

--- a/zone-service/src/test/java/org/cloudfoundry/identity/uaa/zone/OrchestratorZoneServiceTests.java
+++ b/zone-service/src/test/java/org/cloudfoundry/identity/uaa/zone/OrchestratorZoneServiceTests.java
@@ -11,13 +11,12 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
 import java.security.Security;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Stream;
-
-import net.bytebuddy.utility.RandomString;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.cloudfoundry.identity.uaa.client.ClientDetailsValidator;
@@ -108,10 +107,12 @@ public class OrchestratorZoneServiceTests {
 
 
     private IdentityZone mockIdentityZone;
+    private ApplicationEventPublisher applicationEventPublisher;
 
     @BeforeEach
     public void beforeEachTest() {
         mockIdentityZone = mock(IdentityZone.class);
+        applicationEventPublisher = mock(ApplicationEventPublisher.class);
         zoneProvisioning = mock(IdentityZoneProvisioning.class);
         idpProvisioning = mock(IdentityProviderProvisioning.class);
         groupProvisioning = mock(ScimGroupProvisioning.class);
@@ -153,6 +154,7 @@ public class OrchestratorZoneServiceTests {
 
     @Test
     public void testDeleteZone() {
+        zoneService.setApplicationEventPublisher(applicationEventPublisher);
         IdentityZone identityZone = buildIdentityZone();
         when(zoneProvisioning.retrieveByName(any())).thenReturn(identityZone);
         ResponseEntity<?> response = zoneService.deleteZone(identityZone.getName());
@@ -188,7 +190,7 @@ public class OrchestratorZoneServiceTests {
     }
 
     @Test
-    public void testCreateZone() throws OrchestratorZoneServiceException {
+    public void testCreateZone() throws OrchestratorZoneServiceException, IOException {
         Security.addProvider(new BouncyCastleProvider());
         OrchestratorZoneRequest zoneRequest =  getOrchestratorZoneRequest(ZONE_NAME, ADMIN_CLIENT_SECRET,
                                                                           SUB_DOMAIN_NAME);


### PR DESCRIPTION
Reuses business logics from existing /identityzones [2]

- Added post createZone method based on documentation [1]
- Added validation and service exception and error message specific
  for orchestrator zone service and controller.
- Added steps and logics as per service-broker provisionZone
  flow. [3]
- if subdomain is not passed as request body during create zone, generated uuid is being set to id and same id to subdomain.
     - During getOrchestratorZoneDetails call, we get as updated
       response parameters as empty {}, and connection detail
       will have the generated uuid and db stored uuid as subdomain
       value.
- Updated spring security config to include orchestrator zone create API.
- Updated required qualifiers to orchestrator zone configuration.

[1] https://devcloud.swcoe.ge.com/devspace/pages/viewpage.action?spaceKey=RMOCM&title=Orchestrator+UAA+Zone+provisioning+API#OrchestratorUAAZoneprovisioningAPI-POSTAPI:
[2] https://docs.cloudfoundry.org/api/uaa/version/75.18.0/index.html#creating-an-identity-zone
[3] https://github.build.ge.com/predix/security-service-broker/blob/develop/service-broker-service/src/main/java/com/ge/predix/servicebroker/service/UaaZoneProvisioner.java#L160