### PR TITLE
Use proxy for gesos-apikey.gecloud.io domain to avoid timeouts

### DIFF
--- a/gesos-image-build.pipeline
+++ b/gesos-image-build.pipeline
@@ -42,6 +42,10 @@ pipeline {
                 script {
                     setBuildStatus(repoStatusReportUrl, gitCommitStatusContext, 'in progress', 'pending')
                     currentBuild.displayName = "#${env.BUILD_NUMBER} (IAM Container Config Branch Name: ${params.IAM_CONTAINER_CONFIG_BRANCH_NAME}, Image Tag: ${params.IMAGE_TAG})"
+
+                    sh 'echo 10.229.23.137 gesos-apikey.gecloud.io >> /etc/hosts'
+                    sh 'echo 10.229.23.151 gesos-apikey.gecloud.io >> /etc/hosts'
+
                     result = sh(
                         script: """
                                     curl -sSL -X POST -H 'x-api-key: ${GESOS_API_KEY}' \\


### PR DESCRIPTION
One of the three IPs of gesos-apikey.gecloud.io domain resolves to 3.x.x.x. That creates 3pocalypse problem [1] that cause timeouts when connecting to gesos-apikey.gecloud.io. To resolve, Propel team added gesos-apikey.gecloud.io domain to their proxy server. Route traffic to gesos-apikey.gecloud.io through proxy to avoid timeouts.

- Add proxy entries for gesos-apikey.gecloud.io domain to Jenkins /etc/hosts

[1] https://propel.ci.build.ge.com/docs/solutions/3pocalypse-solution/

This pull requested created for UAA copy of UMS (https://github.build.ge.com/predix/user-management-ci-config/pull/44)