### PR TITLE
Create orchestrator zone API return conflict on duplicate subdomain

### DIFF
--- a/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/OrchestratorZoneController.java
+++ b/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/OrchestratorZoneController.java
@@ -1,5 +1,6 @@
 package org.cloudfoundry.identity.uaa.zone;
 
+import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.METHOD_NOT_ALLOWED;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
@@ -74,10 +75,16 @@ public class OrchestratorZoneController {
 
     @ExceptionHandler(value = { HttpMessageNotReadableException.class, MethodArgumentNotValidException.class,
                                 MissingServletRequestParameterException.class, ConstraintViolationException.class,
-                                ZoneAlreadyExistsException.class, OrchestratorZoneServiceException.class})
+                                OrchestratorZoneServiceException.class})
     public ResponseEntity<OrchestratorErrorResponse> badRequest(Exception ex)
     {
         return ResponseEntity.badRequest().body(new OrchestratorErrorResponse(ex.getMessage()));
+    }
+
+    @ExceptionHandler(value = { ZoneAlreadyExistsException.class })
+    public ResponseEntity<OrchestratorErrorResponse> zoneAlreadyExist(Exception ex)
+    {
+        return ResponseEntity.status(CONFLICT).body(new OrchestratorErrorResponse(ex.getMessage()));
     }
 
     @ExceptionHandler(value = { ZoneDoesNotExistsException.class })

--- a/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/OrchestratorZoneService.java
+++ b/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/OrchestratorZoneService.java
@@ -246,7 +246,9 @@ public class OrchestratorZoneService implements ApplicationEventPublisherAware {
         try{
             identityZone = zoneProvisioning.retrieveByName(name);
             if(identityZone != null){
-                throw new ZoneAlreadyExistsException("Orchestrator zone already exists for name:  " + name );
+                String errorMessage = String.format("The zone name %s is already taken. Please use a different " +
+                                                    "zone name", name);
+                throw new ZoneAlreadyExistsException(errorMessage);
             }
         } catch (ZoneDoesNotExistsException e){
             String message = String.format("Its okey! Zone with name %s does not exists ", name);
@@ -296,10 +298,16 @@ public class OrchestratorZoneService implements ApplicationEventPublisherAware {
             logger.debug("Zone - creating zone name [" + identityZone.getName() + "]");
             created = zoneProvisioning.create(identityZone);
             logger.debug("Zone - created zone name [" + identityZone.getName() + "]");
-        } catch (Exception e) {
-            String errorMessage = String.format("Unable to create identity zone for zone name : %s", identityZone.getName());
+        } catch (ZoneAlreadyExistsException e) {
+            String errorMessage = String.format("The subdomain name %s is already taken. Please use a different subdomain",
+                                                identityZone.getSubdomain());
             logger.error(errorMessage, e);
-            throw new OrchestratorZoneServiceException(errorMessage+ " Exception is : " + e.getMessage());
+            throw new ZoneAlreadyExistsException(errorMessage);
+        } catch (Exception e) {
+            String errorMessage = String.format("Unexpected exception while creating identity zone for zone name : " +
+                                                "%s", identityZone.getName());
+            logger.error(errorMessage, e);
+            throw new OrchestratorZoneServiceException(errorMessage);
         }
         return created;
     }


### PR DESCRIPTION
- Create orchestrator zone API return 409 Conflict on duplicate subdomain
- OrchestratorZoneController return 409 Conflict and error message "The <CUSTOM_SUBDOMAIN> name is already taken. Please use a different subdomain."
- Updated exception handling in service class to throw ZoneAlreadyExistsException
- Added return 409 Conflict in controller error handler.