### PR TITLE
Orchestrator zone POST api input validation using annotations

### DIFF
--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/zones/OrchestratorZoneControllerMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/zones/OrchestratorZoneControllerMockMvcTests.java
@@ -47,7 +47,6 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.security.oauth2.provider.ClientRegistrationService;
 import org.springframework.security.oauth2.provider.client.BaseClientDetails;
 import org.springframework.test.web.servlet.MockMvc;
@@ -165,7 +164,7 @@ public class OrchestratorZoneControllerMockMvcTests {
     void testGetZone_nameEmptyError(String url) throws Exception {
         performMockMvcCallAndAssertError(get(url), status().isBadRequest(),
                                          JsonUtils.writeValueAsString(
-                                             new OrchestratorErrorResponse("getZone.name: must not be empty")),
+                                             new OrchestratorErrorResponse("name must be specified")),
                                          orchestratorClientZonesReadToken);
     }
 
@@ -321,7 +320,7 @@ public class OrchestratorZoneControllerMockMvcTests {
                     .header("Authorization", "Bearer " + orchestratorClientZonesWriteToken))
             .andExpect(status().isBadRequest()).andReturn();
         assertEquals(APPLICATION_JSON_VALUE, result.getResponse().getContentType());
-        assertTrue(result.getResponse().getContentAsString().contains("default message [name]]; default message [must not be empty]]"));
+        assertTrue(result.getResponse().getContentAsString().contains("name must not be blank"));
     }
 
     @ParameterizedTest
@@ -337,8 +336,9 @@ public class OrchestratorZoneControllerMockMvcTests {
                     .header("Authorization", "Bearer " + orchestratorClientZonesWriteToken))
             .andExpect(status().isBadRequest()).andReturn();
         assertEquals(APPLICATION_JSON_VALUE, result.getResponse().getContentType());
-        assertTrue(result.getResponse().getContentAsString().contains("Special characters are not allowed in the subdomain " +
-                                                                      "name except hyphen which can be specified in the middle."));
+        assertTrue(result.getResponse().getContentAsString().contains("parameters.subdomain " +
+                                                                      "is invalid. Special characters are not allowed in the " +
+                                                                      "subdomain name except hyphen which can be specified in the middle"));
     }
 
     @ParameterizedTest
@@ -354,11 +354,9 @@ public class OrchestratorZoneControllerMockMvcTests {
                     .header("Authorization", "Bearer " + orchestratorClientZonesWriteToken))
             .andExpect(status().isBadRequest()).andReturn();
 
-        String expected = JsonUtils.writeValueAsString(
-            new OrchestratorErrorResponse("The adminClientSecret field cannot contain" +
-                                          " spaces or cannot be blank."));
         assertEquals(APPLICATION_JSON_VALUE, result.getResponse().getContentType());
-        assertEquals(expected, result.getResponse().getContentAsString());
+        assertTrue(result.getResponse().getContentAsString().contains("parameters.adminClientSecret " +
+                                                                      "must not be empty and must not have empty spaces"));
     }
 
     @Test
@@ -376,6 +374,91 @@ public class OrchestratorZoneControllerMockMvcTests {
                     .content(JsonUtils.writeValueAsString(orchestratorZoneRequest))
                     .header("Authorization", "Bearer " + uaaAdminClientToken))
             .andExpect(status().isAccepted()).andReturn();
+    }
+
+    @Test
+    void testCreateZone_MessageNotReadable_InvalidFormatError() throws Exception {
+        MvcResult result = mockMvc
+            .perform(
+                post("/orchestrator/zones")
+                    .contentType(APPLICATION_JSON)
+                    .content("[[[[ ]]]]")
+                    .header("Authorization", "Bearer " + uaaAdminClientToken))
+            .andExpect(status().isBadRequest()).andReturn();
+
+        assertEquals(APPLICATION_JSON_VALUE, result.getResponse().getContentType());
+        assertTrue(result.getResponse().getContentAsString().contains("Request failed due to a validation error"));
+    }
+
+    @Test
+    void testCreateZone_MessageNotReadable_JsonMappingException() throws Exception {
+        MvcResult result = mockMvc
+            .perform(
+                post("/orchestrator/zones")
+                    .contentType(APPLICATION_JSON)
+                    .content("{\n" +
+                             "  \"name\": \"tes5000-00\",\n" +
+                             "  \"parameters\": {\n" +
+                             "    \"adminClientSecret\": 0992932.303203.00223\n" +
+                             "    \"subdomain\" : \"uywyyw\"\n" +
+                             "  }\n" +
+                             "}")
+                    .header("Authorization", "Bearer " + uaaAdminClientToken))
+            .andExpect(status().isBadRequest()).andReturn();
+
+        assertEquals(APPLICATION_JSON_VALUE, result.getResponse().getContentType());
+        assertTrue(result.getResponse().getContentAsString().contains("parameters is invalid: Invalid numeric value"));
+    }
+
+    @Test
+    void testCreateZone_MessageNotReadable_MismatchedInputException() throws Exception {
+        MvcResult result = mockMvc
+            .perform(
+                post("/orchestrator/zones")
+                    .contentType(APPLICATION_JSON)
+                    .content("{\n" +
+                             "  \"name\": [\"323231\", \"323232\", \"323233\"],\n" +
+                             "  \"parameters\": {\n" +
+                             "    \"adminClientSecret\": \"dsfds\",\n" +
+                             "    \"subdomain\" : \"test-zone-0\"\n" +
+                             "  }\n" +
+                             "}")
+                    .header("Authorization", "Bearer " + uaaAdminClientToken))
+            .andExpect(status().isBadRequest()).andReturn();
+
+        assertEquals(APPLICATION_JSON_VALUE, result.getResponse().getContentType());
+        assertTrue(result.getResponse().getContentAsString().contains("name is invalid: Cannot deserialize value of type " +
+                                                                      "`java.lang.String` from Array value"));
+    }
+
+    @Test
+    void testCreateZone_MessageNotReadable_JsonParsingException() throws Exception {
+        MvcResult result = mockMvc
+            .perform(
+                post("/orchestrator/zones")
+                    .contentType(APPLICATION_JSON)
+                    .content("{\n" +
+                             "  \"name\": \"tes5000-00\",\n" +
+                             "}")
+                    .header("Authorization", "Bearer " + uaaAdminClientToken))
+            .andExpect(status().isBadRequest()).andReturn();
+
+        assertEquals(APPLICATION_JSON_VALUE, result.getResponse().getContentType());
+        assertTrue(result.getResponse().getContentAsString().contains("Unexpected character"));
+    }
+
+    @Test
+    void testCreateZone_WithoutPayload() throws Exception {
+        MvcResult result = mockMvc
+            .perform(
+                post("/orchestrator/zones")
+                    .contentType(APPLICATION_JSON)
+                    .content("")
+                    .header("Authorization", "Bearer " + uaaAdminClientToken))
+            .andExpect(status().isBadRequest()).andReturn();
+
+        assertEquals(APPLICATION_JSON_VALUE, result.getResponse().getContentType());
+        assertTrue(result.getResponse().getContentAsString().contains("Required request body is missing"));
     }
 
     //TODO: delete once the orchestrator create API implemented
@@ -473,7 +556,9 @@ public class OrchestratorZoneControllerMockMvcTests {
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
             return Stream.of(
+                Arguments.of("     "),
                 Arguments.of("sub#-domain"),
+                Arguments.of("sub    domain"),
                 Arguments.of("-subdomainStartsWithHYphen"),
                 Arguments.of("subdomainEndsWithHYphen-"),
                 Arguments.of("sub\\\\domaincontainsslash"),

--- a/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/ErrorMessageUtil.java
+++ b/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/ErrorMessageUtil.java
@@ -1,0 +1,77 @@
+package org.cloudfoundry.identity.uaa.zone;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.util.CollectionUtils;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.validation.ObjectError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+
+public class ErrorMessageUtil {
+
+    public static final String ADMIN_CLIENT_CREDENTIALS_CANNOT_CONTAIN_SPACES_OR_BLANK =
+        "field cannot contain spaces or cannot be blank.";
+    public static final String MANDATORY_VALIDATION_MESSAGE = "must be specified";
+    public static final String ADMIN_CLIENT_CREDENTIALS_VALIDATION_PATTERN = "^\\p{Graph}+$";
+    public static final String ADMIN_CLIENT_CREDENTIALS_VALIDATION_MESSAGE = "must not be empty and must not have empty " +
+                                                                             "spaces";
+    public static final String UAA_CUSTOM_SUBDOMAIN_PATTERN = "(?:[A-Za-z0-9][A-Za-z0-9\\-]{0,61}[A-Za-z0-9]|[A-Za-z0-9])";
+    public static final String UAA_CUSTOM_SUBDOMAIN_MESSAGE = "is invalid. Special characters are not allowed in the " +
+                                                              "subdomain name except hyphen which can be specified in the middle";
+
+    public static final String INVALID_FORMAT_ERROR_MESSAGE = "Request failed due to a validation error";
+
+    public static final String getAffectedProperty(ObjectError objectError) {
+        return objectError instanceof FieldError ? ((FieldError)objectError).getField() : objectError.getObjectName();
+    }
+    public static final String getErrorMessagesConstraintViolation(ConstraintViolationException ex) {
+        Set<String> errorMessages = new HashSet<>();
+        for (ConstraintViolation<?> violation : ex.getConstraintViolations()) {
+            String parameter = violation.getPropertyPath().toString();
+            errorMessages.add(parameter.substring(parameter.indexOf(".")+1) + " " + violation.getMessage());
+        }
+        return String.join("; ", errorMessages);
+    }
+
+    public static final String getErrorMessagesMethodArgumentInvalid(MethodArgumentNotValidException ex) {
+        BindingResult bindingResult = ex.getBindingResult();
+        Set<String> errorMessages = new HashSet<>();
+        for (ObjectError objectError: bindingResult.getAllErrors()) {
+            String message = ErrorMessageUtil.getAffectedProperty(objectError) + " "+ objectError.getDefaultMessage();
+            errorMessages.add(message);
+        }
+        return String.join("; ", errorMessages);
+    }
+
+    public static final String getErrorMessagesHttpMessageNotReadable(HttpMessageNotReadableException exception) {
+        String errorMessage = INVALID_FORMAT_ERROR_MESSAGE;
+        Throwable cause = exception.getCause();
+        if (cause instanceof JsonParseException) {
+            JsonParseException jsonParseException = (JsonParseException) cause;
+            errorMessage = jsonParseException.getOriginalMessage();
+        } else if (cause instanceof JsonMappingException) {
+            JsonMappingException jsonMappingException = (JsonMappingException) cause;
+            if (!CollectionUtils.isEmpty(jsonMappingException.getPath())) {
+                errorMessage = jsonMappingException.getOriginalMessage();
+                errorMessage = getErrorMessage(errorMessage, jsonMappingException);
+            }
+        } else if (cause == null) {
+            errorMessage = exception.getMessage();
+        }
+        return errorMessage;
+    }
+
+    private static String getErrorMessage(final String errorMessage, JsonMappingException jsonMappingException) {
+        return jsonMappingException.getPath().stream().map(
+            error -> error.getFieldName() + " is invalid: " + errorMessage).collect(Collectors.joining("; "));
+    }
+}

--- a/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/OrchestratorZoneController.java
+++ b/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/OrchestratorZoneController.java
@@ -1,5 +1,9 @@
 package org.cloudfoundry.identity.uaa.zone;
 
+import static org.cloudfoundry.identity.uaa.zone.ErrorMessageUtil.MANDATORY_VALIDATION_MESSAGE;
+import static org.cloudfoundry.identity.uaa.zone.ErrorMessageUtil.getErrorMessagesHttpMessageNotReadable;
+import static org.cloudfoundry.identity.uaa.zone.ErrorMessageUtil.getErrorMessagesConstraintViolation;
+import static org.cloudfoundry.identity.uaa.zone.ErrorMessageUtil.getErrorMessagesMethodArgumentInvalid;
 import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
@@ -39,10 +43,9 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/orchestrator/zones")
 public class OrchestratorZoneController {
 
+    public static final String GET_ZONE_PREFIX = "getZone.";
     private static final Logger logger = LoggerFactory.getLogger(OrchestratorZoneController.class);
     private final OrchestratorZoneService zoneService;
-
-    public static final String MANDATORY_VALIDATION_MESSAGE = "must not be empty";
 
     public OrchestratorZoneController(OrchestratorZoneService zoneService) {
         this.zoneService = zoneService;
@@ -75,8 +78,7 @@ public class OrchestratorZoneController {
         throw new OperationNotSupportedException("Put Operation not Supported");
     }
 
-    @ExceptionHandler(value = { HttpMessageNotReadableException.class, MethodArgumentNotValidException.class,
-                                MissingServletRequestParameterException.class, ConstraintViolationException.class,
+    @ExceptionHandler(value = { MissingServletRequestParameterException.class,
                                 OrchestratorZoneServiceException.class})
     public ResponseEntity<OrchestratorErrorResponse> badRequest(Exception ex)
     {
@@ -111,5 +113,25 @@ public class OrchestratorZoneController {
     public ResponseEntity<OrchestratorErrorResponse> internalServerError(Exception ex)
     {
         return ResponseEntity.status(INTERNAL_SERVER_ERROR).body(new OrchestratorErrorResponse(ex.getMessage()));
+    }
+
+    @ExceptionHandler(value = { HttpMessageNotReadableException.class })
+    public ResponseEntity<OrchestratorErrorResponse> messageReadableException(HttpMessageNotReadableException ex)
+    {
+        return ResponseEntity.badRequest()
+                             .body(new OrchestratorErrorResponse(getErrorMessagesHttpMessageNotReadable(ex)));
+    }
+
+    @ExceptionHandler(value = { MethodArgumentNotValidException.class })
+    public ResponseEntity<OrchestratorErrorResponse> methodArgumentException(MethodArgumentNotValidException ex) {
+        return ResponseEntity.badRequest()
+                             .body(new OrchestratorErrorResponse(getErrorMessagesMethodArgumentInvalid(ex)));
+    }
+
+    @ExceptionHandler(value = { ConstraintViolationException.class})
+    public ResponseEntity<OrchestratorErrorResponse> constraintViolationException(ConstraintViolationException ex)
+    {
+        return ResponseEntity.badRequest()
+                             .body(new OrchestratorErrorResponse(getErrorMessagesConstraintViolation(ex)));
     }
 }

--- a/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/model/OrchestratorZone.java
+++ b/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/model/OrchestratorZone.java
@@ -1,16 +1,45 @@
 package org.cloudfoundry.identity.uaa.zone.model;
 
+import static org.cloudfoundry.identity.uaa.zone.ErrorMessageUtil.ADMIN_CLIENT_CREDENTIALS_CANNOT_CONTAIN_SPACES_OR_BLANK;
+import static org.cloudfoundry.identity.uaa.zone.ErrorMessageUtil.ADMIN_CLIENT_CREDENTIALS_VALIDATION_MESSAGE;
+import static org.cloudfoundry.identity.uaa.zone.ErrorMessageUtil.ADMIN_CLIENT_CREDENTIALS_VALIDATION_PATTERN;
+import static org.cloudfoundry.identity.uaa.zone.ErrorMessageUtil.UAA_CUSTOM_SUBDOMAIN_MESSAGE;
+import static org.cloudfoundry.identity.uaa.zone.ErrorMessageUtil.UAA_CUSTOM_SUBDOMAIN_PATTERN;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.experimental.FieldDefaults;
 
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
+@Getter
+@FieldDefaults(makeFinal=true, level= AccessLevel.PRIVATE)
+@ToString
+@EqualsAndHashCode
 @JsonInclude(Include.NON_NULL)
 public class OrchestratorZone {
-    private String adminClientSecret;
-    private String subdomain = null;
+
+    @NotNull(message = ADMIN_CLIENT_CREDENTIALS_CANNOT_CONTAIN_SPACES_OR_BLANK)
+    @Pattern(regexp = ADMIN_CLIENT_CREDENTIALS_VALIDATION_PATTERN,
+             message= ADMIN_CLIENT_CREDENTIALS_VALIDATION_MESSAGE
+    )
+    private final String adminClientSecret;
+
+    @Pattern(regexp = UAA_CUSTOM_SUBDOMAIN_PATTERN,
+             message= UAA_CUSTOM_SUBDOMAIN_MESSAGE)
+    private final String subdomain;
+
+    @JsonCreator
+    public OrchestratorZone(@JsonProperty("adminClientSecret") String adminClientSecret,
+                            @JsonProperty("subdomain") String subdomain) {
+        this.adminClientSecret = adminClientSecret;
+        this.subdomain = subdomain;
+    }
 }

--- a/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/model/OrchestratorZoneRequest.java
+++ b/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/model/OrchestratorZoneRequest.java
@@ -1,11 +1,21 @@
 package org.cloudfoundry.identity.uaa.zone.model;
 
+import static org.cloudfoundry.identity.uaa.zone.ErrorMessageUtil.ADMIN_CLIENT_CREDENTIALS_VALIDATION_MESSAGE;
+import static org.cloudfoundry.identity.uaa.zone.ErrorMessageUtil.ADMIN_CLIENT_CREDENTIALS_VALIDATION_PATTERN;
+import static org.cloudfoundry.identity.uaa.zone.ErrorMessageUtil.MANDATORY_VALIDATION_MESSAGE;
+
 import lombok.Data;
+
+import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 
 @Data
 public class OrchestratorZoneRequest {
-    @NotBlank(message = org.cloudfoundry.identity.uaa.zone.OrchestratorZoneController.MANDATORY_VALIDATION_MESSAGE)
+    @NotBlank
     private String name;
+
+    @Valid
+    @NotNull(message = MANDATORY_VALIDATION_MESSAGE)
     private OrchestratorZone parameters;
 }

--- a/zone-service/src/test/java/org/cloudfoundry/identity/uaa/zone/OrchestratorZoneServiceTests.java
+++ b/zone-service/src/test/java/org/cloudfoundry/identity/uaa/zone/OrchestratorZoneServiceTests.java
@@ -232,40 +232,6 @@ public class OrchestratorZoneServiceTests {
     }
 
     @Test
-    public void testCreateZone_AdminClientSecretEmptyFailWithException() {
-        OrchestratorZoneRequest zoneRequest = getOrchestratorZoneRequest(ZONE_NAME, ADMIN_CLIENT_SECRET_EMPTY, SUB_DOMAIN_NAME);
-        assertEmptyInputThrowException(zoneRequest);
-    }
-
-    private void assertEmptyInputThrowException(OrchestratorZoneRequest zoneRequest) {
-        OrchestratorZoneServiceException exception =
-            assertThrows(OrchestratorZoneServiceException.class, () ->
-                             zoneService.createZone(zoneRequest),
-                         "field cannot contain spaces or cannot be blank.");
-        assertTrue(exception.getMessage().contains("field cannot contain spaces or cannot be blank."));
-    }
-
-    @Test
-    public void testCreateZone_SubDomainWithBlankFailWithException() {
-        OrchestratorZoneRequest zoneRequest = getOrchestratorZoneRequest(ZONE_NAME, ADMIN_CLIENT_SECRET,
-                                                                         SUB_DOMAIN_BLANK_SPACE);
-        assertEmptyInputThrowException(zoneRequest);
-    }
-
-    @ParameterizedTest
-    @ArgumentsSource(SubDomainWithSpaceOrSpecialCharArguments.class)
-    public void testCreateZone_SubDomainWithSpaceOrSpecialCharFailWithException(String subDomain) {
-        OrchestratorZoneRequest zoneRequest = getOrchestratorZoneRequest(ZONE_NAME, ADMIN_CLIENT_SECRET,
-                                                                         subDomain);
-
-        OrchestratorZoneServiceException exception =
-            assertThrows(OrchestratorZoneServiceException.class, () ->
-                             zoneService.createZone(zoneRequest),
-                         "Special characters are not allowed in the subdomain name except hyphen which can be specified in the middle.");
-        assertTrue(exception.getMessage().contains("Special characters are not allowed in the subdomain name except hyphen which can be specified in the middle."));
-    }
-
-    @Test
     public void testCreateZone_DuplicateSubdomainCauseZoneAlreadyExistsException () {
         Security.addProvider(new BouncyCastleProvider());
         OrchestratorZoneRequest zoneRequest =  getOrchestratorZoneRequest(ZONE_NAME, ADMIN_CLIENT_SECRET,
@@ -282,19 +248,6 @@ public class OrchestratorZoneServiceTests {
         verify(zoneProvisioning, times(1)).create(any());
     }
 
-    private static class SubDomainWithSpaceOrSpecialCharArguments implements ArgumentsProvider {
-
-        @Override
-        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-            return Stream.of(
-                Arguments.of("sub#-domain"),
-                Arguments.of("-subdomainStartsWithHYphen"),
-                Arguments.of("subdomainEndsWithHYphen-"),
-                Arguments.of("sub\\\\domaincontainsslash"),
-                Arguments.of("sub$%domaincontainsSpecialChars")
-                            );
-        }
-    }
 
     private OrchestratorZoneRequest getOrchestratorZoneRequest(String name, String adminClientSecret,
                                                                String subDomain) {


### PR DESCRIPTION
Orchestrator zone POST api input validation using annotations

- Add validation annotation into OrchestratorZone
  and OrchestratorZonerequest
- Handle as field validation in the OrchestratorZone data class.
- Handle as field validation in OrchestratorZoneRequest data class
- Added exception handlers in controller class
- Controller will return 400 if validation fails.
- Validation error handling message conversion as like ums evolve
- Adjust handle error messages and exceptions in Orchestrator
  Zone controller
- Added ErrorMessageUtil where all message constants, regex patterns
  and utility methods for message conversion are added.
- As request input validation are taken care using annotations in controller and model classes (OrchestratorZoneRequest and
  OrchestratorZone), removed input field validation from service class