### PR TITLE
Enforce orchestrator name uniqueness

### DIFF
--- a/model/src/main/java/org/cloudfoundry/identity/uaa/zone/OrchestratorZoneEntity.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/zone/OrchestratorZoneEntity.java
@@ -1,0 +1,22 @@
+package org.cloudfoundry.identity.uaa.zone;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class OrchestratorZoneEntity {
+
+    private Long id;
+    private String orchestratorZoneName;
+    private String identityZoneId;
+    private String subdomain;
+    private LocalDateTime created;
+    private LocalDateTime lastModified;
+
+
+}

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/zone/IdentityZoneProvisioning.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/zone/IdentityZoneProvisioning.java
@@ -18,11 +18,17 @@ public interface IdentityZoneProvisioning {
 
     IdentityZone create(IdentityZone identityZone);
 
+    OrchestratorZoneEntity createOrchestratorZone(String identityZoneId, String orchestratorZoneName);
+
     IdentityZone update(IdentityZone identityZone);
 
     IdentityZone retrieve(String id);
 
-    IdentityZone retrieveByName(String name);
+    OrchestratorZoneEntity retrieveByName(String name);
+
+    OrchestratorZoneEntity retrieveByNameIgnoreActiveFlag(String name);
+
+    int deleteOrchestratorZone(String orchestratorZoneName);
 
     IdentityZone retrieveBySubdomain(String subdomain);
 

--- a/server/src/main/resources/org/cloudfoundry/identity/uaa/db/hsqldb/V4_102__Add_ochestrator_zone_table.sql
+++ b/server/src/main/resources/org/cloudfoundry/identity/uaa/db/hsqldb/V4_102__Add_ochestrator_zone_table.sql
@@ -1,0 +1,14 @@
+CREATE TABLE orchestrator_zone (
+    id INTEGER IDENTITY NOT NULL PRIMARY KEY,
+    identity_zone_id VARCHAR(36)  NOT NULL,
+    orchestrator_zone_name  VARCHAR(255)  NOT NULL,
+    created TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    lastmodified TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+CREATE UNIQUE INDEX identity_zone_id_unique_key ON orchestrator_zone (identity_zone_id);
+
+CREATE UNIQUE INDEX orchestrator_name_unique_key ON orchestrator_zone (orchestrator_zone_name);
+
+ALTER TABLE orchestrator_zone ADD CONSTRAINT fk_orchestrator_identity_zone FOREIGN KEY (identity_zone_id)
+    REFERENCES identity_zone (id);

--- a/server/src/main/resources/org/cloudfoundry/identity/uaa/db/postgresql/V4_102__Add_ochestrator_zone_table.sql
+++ b/server/src/main/resources/org/cloudfoundry/identity/uaa/db/postgresql/V4_102__Add_ochestrator_zone_table.sql
@@ -1,0 +1,14 @@
+CREATE TABLE orchestrator_zone (
+    id serial NOT NULL constraint orchestrator_zone_pk PRIMARY KEY,
+    identity_zone_id VARCHAR(36)  NOT NULL,
+    orchestrator_zone_name  VARCHAR(255)  NOT NULL,
+    created TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    lastmodified TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+CREATE UNIQUE INDEX identity_zone_id_unique_key ON orchestrator_zone (identity_zone_id);
+
+CREATE UNIQUE INDEX orchestrator_name_unique_key ON orchestrator_zone (orchestrator_zone_name);
+
+ALTER TABLE orchestrator_zone ADD CONSTRAINT fk_orchestrator_identity_zone FOREIGN KEY (identity_zone_id)
+    REFERENCES identity_zone (id);

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/test/TestUtils.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/test/TestUtils.java
@@ -51,6 +51,7 @@ public class TestUtils {
         jdbcTemplate.update("DELETE FROM group_membership");
         jdbcTemplate.update("DELETE FROM groups");
         jdbcTemplate.update("DELETE FROM identity_provider");
+        jdbcTemplate.update("DELETE FROM orchestrator_zone");
         jdbcTemplate.update("DELETE FROM identity_zone");
         jdbcTemplate.update("DELETE FROM oauth_client_details");
         jdbcTemplate.update("DELETE FROM oauth_code");

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/zones/OrchestratorZoneControllerMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/zones/OrchestratorZoneControllerMockMvcTests.java
@@ -172,22 +172,21 @@ public class OrchestratorZoneControllerMockMvcTests {
     @Test
     void testGetZone() throws Exception {
         //TODO: remove this createIdentityZone method once the create orchestrator zone API is implemented and use it to create zone.
-        IdentityZone identityZone = createIdentityZone();
-        assertNotNull(identityZone);
+        createOrchestratorZoneAndAssert();
         OrchestratorZoneResponse zoneResponse =
-            processZoneAPI(get("/orchestrator/zones"), "test-name", status().isOk(), orchestratorClientZonesReadToken);
+            processZoneAPI(get("/orchestrator/zones"), ZONE_NAME, status().isOk(), orchestratorClientZonesReadToken);
         assertNotNull(zoneResponse);
         assertNotNull(zoneResponse.getParameters());
-        assertEquals(identityZone.getSubdomain(), zoneResponse.getParameters().getSubdomain());
-        assertEquals(identityZone.getSubdomain(), zoneResponse.getConnectionDetails().getSubdomain());
-        String uri = "http://" + identityZone.getSubdomain() + ".localhost";
+        assertEquals(SUB_DOMAIN_NAME, zoneResponse.getParameters().getSubdomain());
+        assertEquals(SUB_DOMAIN_NAME, zoneResponse.getConnectionDetails().getSubdomain());
+        String uri = "http://" + SUB_DOMAIN_NAME + ".localhost";
         assertEquals(uri, zoneResponse.getConnectionDetails().getUri());
         assertEquals("http://localhost:8080/dashboard", zoneResponse.getConnectionDetails().getDashboardUri());
         assertEquals(uri + "/oauth/token", zoneResponse.getConnectionDetails().getIssuerId());
         assertEquals(X_IDENTITY_ZONE_ID, zoneResponse.getConnectionDetails().getZone().getHttpHeaderName());
-        assertEquals(identityZone.getId(), zoneResponse.getConnectionDetails().getZone().getHttpHeaderValue());
+        assertNotNull(zoneResponse.getConnectionDetails().getZone().getHttpHeaderValue());
         // deleting after create and get to avoid multiple value in the database
-        processZoneAPI(delete("/orchestrator/zones"), identityZone.getName(), status().isAccepted(),
+        processZoneAPI(delete("/orchestrator/zones"), ZONE_NAME, status().isAccepted(),
                        orchestratorClientZonesWriteToken);
     }
 
@@ -229,14 +228,14 @@ public class OrchestratorZoneControllerMockMvcTests {
     @Test
     void testDeleteZone() throws Exception {
         //TODO: remove this createIdentityZone method once the create orchestrator zone API is implemented and use it to create zone.
-        IdentityZone identityZone = createIdentityZone();
+        createOrchestratorZoneAndAssert();
         uaaEventListener.clearEvents();
-        processZoneAPI(delete("/orchestrator/zones"), identityZone.getName(), status().isAccepted(),
+        processZoneAPI(delete("/orchestrator/zones"), ZONE_NAME, status().isAccepted(),
                        orchestratorClientZonesWriteToken);
-        performMockMvcCallAndAssertError(get("/orchestrator/zones").param("name", identityZone.getName()),
+        performMockMvcCallAndAssertError(get("/orchestrator/zones").param("name", ZONE_NAME),
                                          status().isNotFound(),
                                          JsonUtils.writeValueAsString(
-                                             new OrchestratorErrorResponse("Zone[test-name] not found.")),
+                                             new OrchestratorErrorResponse("Zone[The Twiglet Zone] not found.")),
                                          orchestratorClientZonesWriteToken);
 
         // Asserting delete event
@@ -364,6 +363,10 @@ public class OrchestratorZoneControllerMockMvcTests {
 
     @Test
     void testCreateZone_Accepted_Success() throws Exception {
+        createOrchestratorZoneAndAssert();
+    }
+
+    private void createOrchestratorZoneAndAssert() throws Exception {
         OrchestratorZoneRequest orchestratorZoneRequest = getOrchestratorZoneRequest(ZONE_NAME,ADMIN_CLIENT_SECRET,
                                                                                      SUB_DOMAIN_NAME);
         MvcResult result = mockMvc

--- a/zone-service/build.gradle
+++ b/zone-service/build.gradle
@@ -14,6 +14,7 @@ dependencies {
         exclude(group: "org.glassfish", module: "jakarta.el")
     }
     implementation(libraries.springSecurityWeb)
+    implementation(libraries.springTx)
     implementation(project(":cloudfoundry-identity-server"))
     implementation(project(":cloudfoundry-identity-model"))
     implementation(project(":cloudfoundry-identity-metrics-data"))

--- a/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/OrchestratorZoneController.java
+++ b/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/OrchestratorZoneController.java
@@ -1,16 +1,16 @@
 package org.cloudfoundry.identity.uaa.zone;
 
 import static org.springframework.http.HttpStatus.CONFLICT;
+import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.METHOD_NOT_ALLOWED;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
-import static org.springframework.http.HttpStatus.FORBIDDEN;
 
 import java.io.IOException;
 import javax.naming.OperationNotSupportedException;
 import javax.validation.ConstraintViolationException;
-import javax.validation.constraints.NotBlank;
 import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
 
 import org.cloudfoundry.identity.uaa.zone.model.OrchestratorErrorResponse;
 import org.cloudfoundry.identity.uaa.zone.model.OrchestratorZoneRequest;
@@ -19,6 +19,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
@@ -30,10 +32,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.security.access.AccessDeniedException;
-import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @Validated
 @RestController("zoneEndpoints")
@@ -50,11 +49,13 @@ public class OrchestratorZoneController {
     }
 
     @GetMapping
+    @Transactional(readOnly = true)
     public ResponseEntity<OrchestratorZoneResponse> getZone(@NotBlank(message = MANDATORY_VALIDATION_MESSAGE) @RequestParam String name) {
         return ResponseEntity.ok(zoneService.getZoneDetails(name));
     }
 
     @PostMapping
+    @Transactional
     public ResponseEntity<?> createOrchestratorZone(@RequestBody @Valid OrchestratorZoneRequest orchestratorZoneRequest )
         throws OrchestratorZoneServiceException, IOException {
         zoneService.createZone(orchestratorZoneRequest);
@@ -62,6 +63,7 @@ public class OrchestratorZoneController {
     }
 
     @DeleteMapping
+    @Transactional
     public ResponseEntity<?> deleteZone(@NotBlank(message = MANDATORY_VALIDATION_MESSAGE) @RequestParam String name)
         throws Exception {
         zoneService.deleteZone(name);

--- a/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/OrchestratorZoneService.java
+++ b/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/OrchestratorZoneService.java
@@ -29,7 +29,7 @@ import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
 import org.bouncycastle.openssl.jcajce.JcePEMEncryptorBuilder;
 import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
-
+import org.cloudfoundry.identity.uaa.audit.event.EntityDeletedEvent;
 import org.cloudfoundry.identity.uaa.client.ClientDetailsValidator;
 import org.cloudfoundry.identity.uaa.client.ClientDetailsValidator.Mode;
 import org.cloudfoundry.identity.uaa.constants.OriginKeys;
@@ -41,25 +41,21 @@ import org.cloudfoundry.identity.uaa.saml.SamlKey;
 import org.cloudfoundry.identity.uaa.scim.ScimGroup;
 import org.cloudfoundry.identity.uaa.scim.ScimGroupProvisioning;
 import org.cloudfoundry.identity.uaa.util.JsonUtils;
-
-import org.cloudfoundry.identity.uaa.audit.event.EntityDeletedEvent;
 import org.cloudfoundry.identity.uaa.zone.model.ConnectionDetails;
 import org.cloudfoundry.identity.uaa.zone.model.OrchestratorZone;
 import org.cloudfoundry.identity.uaa.zone.model.OrchestratorZoneHeader;
-import org.cloudfoundry.identity.uaa.zone.model.OrchestratorZoneResponse;
 import org.cloudfoundry.identity.uaa.zone.model.OrchestratorZoneRequest;
-
+import org.cloudfoundry.identity.uaa.zone.model.OrchestratorZoneResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.common.util.RandomValueStringGenerator;
 import org.springframework.security.oauth2.provider.ClientDetails;
 import org.springframework.security.oauth2.provider.client.BaseClientDetails;
 import org.springframework.util.StringUtils;
-
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 public class OrchestratorZoneService implements ApplicationEventPublisherAware {
@@ -116,12 +112,12 @@ public class OrchestratorZoneService implements ApplicationEventPublisherAware {
     }
 
     public OrchestratorZoneResponse getZoneDetails(String zoneName) {
-        IdentityZone identityZone = zoneProvisioning.retrieveByName(zoneName);
-        OrchestratorZone zone = new OrchestratorZone(null, getSubDomainStr(identityZone));
+        OrchestratorZoneEntity orchestratorZone = zoneProvisioning.retrieveByName(zoneName);
+        OrchestratorZone zone = new OrchestratorZone(null, getSubDomainStr(orchestratorZone));
         String uaaUri = ServletUriComponentsBuilder.fromCurrentContextPath().toUriString();
-        String subDomain = identityZone.getSubdomain();
+        String subDomain = orchestratorZone.getSubdomain();
         String zoneUri = getZoneUri(subDomain, uaaUri);
-        ConnectionDetails connectionDetails = buildConnectionDetails(zoneName, identityZone, zoneUri);
+        ConnectionDetails connectionDetails = buildConnectionDetails(zoneName, orchestratorZone, zoneUri);
         return new OrchestratorZoneResponse(zoneName, zone, connectionDetails);
     }
 
@@ -129,9 +125,11 @@ public class OrchestratorZoneService implements ApplicationEventPublisherAware {
         IdentityZone previous = IdentityZoneHolder.get();
         try {
             logger.debug("Zone - deleting Name[" + zoneName + "]");
-            IdentityZone zone = zoneProvisioning.retrieveByName(zoneName);
+            OrchestratorZoneEntity orchestratorZone = zoneProvisioning.retrieveByName(zoneName);
+            IdentityZone zone = zoneProvisioning.retrieve(orchestratorZone.getIdentityZoneId());
             IdentityZoneHolder.set(zone);
             if (publisher != null && zone != null) {
+                zoneProvisioning.deleteOrchestratorZone(zoneName);
                 publisher.publishEvent(
                     new EntityDeletedEvent<>(zone, SecurityContextHolder.getContext().getAuthentication(),
                                              IdentityZoneHolder.getCurrentZoneId()));
@@ -146,14 +144,14 @@ public class OrchestratorZoneService implements ApplicationEventPublisherAware {
         }
     }
 
-    private ConnectionDetails buildConnectionDetails(String zoneName, IdentityZone identityZone,
+    private ConnectionDetails buildConnectionDetails(String zoneName, OrchestratorZoneEntity orchestratorZone,
                                                      String zoneUri) {
         ConnectionDetails connectionDetails = new ConnectionDetails();
         connectionDetails.setUri(zoneUri);
         connectionDetails.setIssuerId(zoneUri + "/oauth/token");
-        connectionDetails.setSubdomain(identityZone.getSubdomain());
+        connectionDetails.setSubdomain(orchestratorZone.getSubdomain());
         connectionDetails.setDashboardUri(uaaDashboardUri);
-        OrchestratorZoneHeader zoneHeader = new OrchestratorZoneHeader(X_IDENTITY_ZONE_ID, identityZone.getId());
+        OrchestratorZoneHeader zoneHeader = new OrchestratorZoneHeader(X_IDENTITY_ZONE_ID, orchestratorZone.getIdentityZoneId());
         connectionDetails.setZone(zoneHeader);
         return connectionDetails;
     }
@@ -175,9 +173,9 @@ public class OrchestratorZoneService implements ApplicationEventPublisherAware {
         this.publisher = applicationEventPublisher;
     }
 
-    private String getSubDomainStr(IdentityZone identityZone) {
-        String id = identityZone.getId();
-        String subDomain = identityZone.getSubdomain();
+    private String getSubDomainStr(OrchestratorZoneEntity orchestratorZone) {
+        String id = orchestratorZone.getIdentityZoneId();
+        String subDomain = orchestratorZone.getSubdomain();
         if(id.equals(subDomain)){
             subDomain = null;
         }
@@ -194,8 +192,6 @@ public class OrchestratorZoneService implements ApplicationEventPublisherAware {
         String name = zoneRequest.getName();
         String adminClientSecret = getAdminClientSecret(zoneRequest);
 
-        checkOrchestratorZoneExists(name);
-
         String subdomain = zoneRequest.getParameters().getSubdomain();
         String id = UUID.randomUUID().toString();
         subdomain = getSubDomain(subdomain, id);
@@ -205,6 +201,9 @@ public class OrchestratorZoneService implements ApplicationEventPublisherAware {
         IdentityZone previous = IdentityZoneHolder.get();
         try {
             IdentityZone created = createIdentityZone(identityZone);
+            // This DAO method will throw ConstraintViolationException
+            // if there is a duplicate entry in orchestrator_zone table
+            zoneProvisioning.createOrchestratorZone(identityZone.getId(), name);
             IdentityZoneHolder.set(created);
             createDefaultIdp(created);
             createUserGroups(created);
@@ -231,21 +230,6 @@ public class OrchestratorZoneService implements ApplicationEventPublisherAware {
             subdomain = customSubdomain;
         }
         return subdomain;
-    }
-
-    private void checkOrchestratorZoneExists(String name) throws ZoneAlreadyExistsException {
-        IdentityZone identityZone = null;
-        try{
-            identityZone = zoneProvisioning.retrieveByName(name);
-            if(identityZone != null){
-                String errorMessage = String.format("The zone name %s is already taken. Please use a different " +
-                                                    "zone name", name);
-                throw new ZoneAlreadyExistsException(errorMessage);
-            }
-        } catch (ZoneDoesNotExistsException e){
-            String message = String.format("Its okey! Zone with name %s does not exists ", name);
-            logger.debug(message, e);
-        }
     }
 
     private void createZoneAdminClient(String adminClientSecret, IdentityZone created)


### PR DESCRIPTION
Add flyway script for postgresql and hsqldb to add orchestrator_zone table.
Create unique key for orchestrator_zone_name to ensure only one entry for an orchestrator zone
Also create unique key for identity_zone_id to make sure only one entry
 for an identity_zone. there should be one-to-one mapping between
 orchestrator_zone and identity_zone
create a foreign key for faster retrieval with join query.