### PR TITLE
Store SAML certificate in PEM format

### DIFF
--- a/zone-service/src/test/java/org/cloudfoundry/identity/uaa/zone/OrchestratorZoneServiceTests.java
+++ b/zone-service/src/test/java/org/cloudfoundry/identity/uaa/zone/OrchestratorZoneServiceTests.java
@@ -206,6 +206,18 @@ public class OrchestratorZoneServiceTests {
     }
 
     @Test
+    public void testGenerateIdentityZone() throws OrchestratorZoneServiceException, IOException, InvalidIdentityZoneDetailsException {
+        Security.addProvider(new BouncyCastleProvider());
+
+        MfaConfigValidator mfaConfigValidator = mock(MfaConfigValidator.class);
+        GeneralIdentityZoneConfigurationValidator configValidator = new GeneralIdentityZoneConfigurationValidator(mfaConfigValidator);
+        GeneralIdentityZoneValidator validator = new GeneralIdentityZoneValidator(configValidator);
+
+        IdentityZone identityZone = zoneService.generateIdentityZone(ZONE_NAME, SUB_DOMAIN_NAME, UUID.randomUUID().toString());
+        validator.validate(identityZone, IdentityZoneValidator.Mode.CREATE);
+    }
+
+    @Test
     public void testCreateZoneDetails_AccessDeniedException() {
         when(mockIdentityZone.getId()).thenReturn("not uaa");
         IdentityZoneHolder.set(mockIdentityZone);


### PR DESCRIPTION
SAML certificate for Orchestrator provisioned zone is generated by Bouncycastle in DER format as binary encoded certificate data. To read public key from certificate, UAA is using Bouncycastle PEM parser that expects certificate in PEM format as a charset encoded string.

Convert certificate from DER to PEM before storing to make it compatible with Bouncycastle PEM parser and to avoid DecoderException “unable to decode base64 string” when loading.

- In OrchestratorZoneService, use Java Base64 `encodeToString` instead of `Array.toString` to convert SAML certificate DER byte array into PEM compatible string. `encodeToString` converts binary array into ISO-8859-1 charset encoded string while `Array.toString` just creates a comma-delimited list of array's elements.
- Add test to validate generated zone using UAA `GeneralIdentityZoneConfigurationValidator`. This validator checks all aspects of zone configuration including token signing key and SAML certificate.
- In OrchestratorZoneService, remove overlooked unused imports