### PR TITLE
Add additional authorities for orchestrator zone api

### DIFF
--- a/server/src/test/java/org/cloudfoundry/identity/uaa/test/TestAccountSetup.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/test/TestAccountSetup.java
@@ -106,6 +106,9 @@ public class TestAccountSetup extends TestWatchman {
             if (!cfClientExists(client)) {
                 createCfClient(client);
             }
+            if (!orchestratorClientExists(client)) {
+                createOrchestratorClient(client);
+            }
             initialized = true;
         }
         resource = testAccounts.getClientCredentialsResource("oauth.clients.scim", "scim", "scimsecret");
@@ -135,6 +138,13 @@ public class TestAccountSetup extends TestWatchman {
         createClient(client, testAccounts.getClientDetails("oauth.clients.app", clientDetails));
     }
 
+    private void createOrchestratorClient(RestOperations client) {
+        BaseClientDetails clientDetails = new BaseClientDetails("orchestrator-zone-provisioner", "none",
+                "uaa.none", "client_credentials","orchestrator.zones.write,orchestrator.zones.read");
+        clientDetails.setClientSecret("orchestratorsecret");
+        createClient(client, testAccounts.getClientDetails("oauth.clients.orchestrator", clientDetails));
+    }
+
     private void createClient(RestOperations client, ClientDetails clientDetails) {
         ResponseEntity<String> response = client.postForEntity(serverRunning.getClientsUri(), clientDetails,
                         String.class);
@@ -159,6 +169,11 @@ public class TestAccountSetup extends TestWatchman {
     private boolean appClientExists(RestOperations client) {
         return clientExists(client,
                         testAccounts.getClientCredentialsResource("oauth.clients.app", "app", "appclientsecret"));
+    }
+
+    private boolean orchestratorClientExists(RestOperations client) {
+        return clientExists(client,
+                testAccounts.getClientCredentialsResource("oauth.clients.orchestrator", "orchestrator-zone-provisioner", "orchestratorsecret"));
     }
 
     private void initializeUserAccount(RestOperations client) {

--- a/uaa/src/main/webapp/WEB-INF/spring/multitenant-endpoints.xml
+++ b/uaa/src/main/webapp/WEB-INF/spring/multitenant-endpoints.xml
@@ -24,10 +24,18 @@
           entry-point-ref="oauthAuthenticationEntryPoint"
           use-expressions="true" authentication-manager-ref="emptyAuthenticationManager"
           xmlns="http://www.springframework.org/schema/security">
-        <intercept-url pattern="/orchestrator/zones" access="#oauth2.hasScopeInAuthZone('zones.{zone.id}.admin') or #oauth2.hasScope('zones.write')" method="POST"/>
-        <intercept-url pattern="/orchestrator/zones" access="#oauth2.hasScopeInAuthZone('zones.read') or #oauth2.hasScopeInAuthZone('zones.{zone.id}.admin') or #oauth2.hasScope('zones.write')" method="GET"/>
-        <intercept-url pattern="/orchestrator/zones" access="#oauth2.hasScopeInAuthZone('zones.{zone.id}.admin') or #oauth2.hasScope('zones.write')" method="DELETE"/>
-        <intercept-url pattern="/orchestrator/zones" access="#oauth2.hasScopeInAuthZone('zones.{zone.id}.admin') or #oauth2.hasScope('zones.write')" method="PUT"/>
+        <intercept-url pattern="/orchestrator/zones"
+                       access="#oauth2.hasScope('orchestrator.zones.write') or #oauth2.hasScopeInAuthZone('zones.{zone.id}.admin') or #oauth2.hasScope('zones.write')"
+                       method="POST"/>
+        <intercept-url pattern="/orchestrator/zones"
+                       access="#oauth2.hasScope('orchestrator.zones.read') or #oauth2.hasScope('orchestrator.zones.write') or #oauth2.hasScopeInAuthZone('zones.read') or #oauth2.hasScopeInAuthZone('zones.{zone.id}.admin') or #oauth2.hasScope('zones.write')"
+                       method="GET"/>
+        <intercept-url pattern="/orchestrator/zones"
+                       access="#oauth2.hasScope('orchestrator.zones.write') or #oauth2.hasScopeInAuthZone('zones.{zone.id}.admin') or #oauth2.hasScope('zones.write')"
+                       method="DELETE"/>
+        <intercept-url pattern="/orchestrator/zones"
+                       access="#oauth2.hasScope('orchestrator.zones.write') or #oauth2.hasScopeInAuthZone('zones.{zone.id}.admin') or #oauth2.hasScope('zones.write')"
+                       method="PUT"/>
 
         <intercept-url pattern="/**" access="denyAll"/>
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/OrchestratorZoneControllerIntegrationTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/OrchestratorZoneControllerIntegrationTests.java
@@ -1,5 +1,6 @@
 package org.cloudfoundry.identity.uaa.integration;
 
+import static org.cloudfoundry.identity.uaa.integration.util.IntegrationTestUtils.assertSupportsZoneDNS;
 import static org.cloudfoundry.identity.uaa.zone.OrchestratorZoneService.X_IDENTITY_ZONE_ID;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.core.Is.is;
@@ -268,6 +269,7 @@ public class OrchestratorZoneControllerIntegrationTests {
 
     @Test
     public void testCreateZone_WithZoneConfigValidation() throws Throwable {
+        assertSupportsZoneDNS();
 
         // Create zone using orchestrator zone api
         String zoneName = ORCHESTRATOR_INT_TEST_ZONE;

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/OrchestratorZoneControllerIntegrationTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/OrchestratorZoneControllerIntegrationTests.java
@@ -74,7 +74,7 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestTemplate;
 
-@OAuth2ContextConfiguration(OrchestratorZoneControllerIntegrationTests.ZoneClient.class)
+@OAuth2ContextConfiguration(OrchestratorZoneControllerIntegrationTests.OrchestratorClient.class)
 public class OrchestratorZoneControllerIntegrationTests {
 
     public static final String ZONE_NAME = "The Twiglet Zone";
@@ -481,11 +481,12 @@ public class OrchestratorZoneControllerIntegrationTests {
         assertTrue(getResponse.getBody().contains("name must not be blank"));
     }
 
-    static class ZoneClient extends ClientCredentialsResourceDetails {
+    static class OrchestratorClient extends ClientCredentialsResourceDetails {
 
-        public ZoneClient(Object target) {
+        public OrchestratorClient(Object target) {
             OrchestratorZoneControllerIntegrationTests test = (OrchestratorZoneControllerIntegrationTests) target;
-            ClientCredentialsResourceDetails resource = test.testAccounts.getAdminClientCredentialsResource();
+            ClientCredentialsResourceDetails resource = test.testAccounts.getClientCredentialsResource(
+                    new String[] {"uaa.none"}, "orchestrator-zone-provisioner", "orchestratorsecret");
             setClientId(resource.getClientId());
             setClientSecret(resource.getClientSecret());
             setId(getClientId());

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/util/IntegrationTestUtils.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/util/IntegrationTestUtils.java
@@ -251,7 +251,8 @@ public class IntegrationTestUtils {
                 "testzone3.localhost",
                 "testzone4.localhost",
                 "testzonedoesnotexist.localhost",
-                "testzoneinactive.localhost"
+                "testzoneinactive.localhost",
+                "orchestrator-int-test-zone.localhost"
         ).forEach(IntegrationTestUtils::assertLoopback);
     }
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/zones/OrchestratorZoneControllerMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/zones/OrchestratorZoneControllerMockMvcTests.java
@@ -258,7 +258,9 @@ public class OrchestratorZoneControllerMockMvcTests {
     void testDeleteZone_Forbidden() throws Exception {
         performMockMvcCallAndAssertError(delete("/orchestrator/zones").param("name", "random-name"),
                                          status().isForbidden(),
-                                         "{\"error\":\"insufficient_scope\",\"error_description\":\"Insufficient scope for this resource\",\"scope\":\"uaa.admin zones.uaa.admin zones.write\"}",
+                                         "{\"error\":\"insufficient_scope\",\"error_description\":\"Insufficient " +
+                                         "scope for this resource\",\"scope\":\"uaa.admin orchestrator.zones.write zones.uaa.admin zones" +
+                                         ".write\"}",
                                          orchestratorClientZonesReadToken);
     }
 
@@ -277,7 +279,8 @@ public class OrchestratorZoneControllerMockMvcTests {
         performMockMvcCallAndAssertError(put("/orchestrator/zones").contentType(APPLICATION_JSON).content(
                                              "{\"name\": \"\",\"parameters\": {\"adminSecret\": \"\",\"subDomain\": \"\"}}"),
                                          status().isForbidden(),
-                                         "{\"error\":\"insufficient_scope\",\"error_description\":\"Insufficient scope for this resource\",\"scope\":\"uaa.admin zones.uaa.admin zones.write\"}",
+                                         "{\"error\":\"insufficient_scope\",\"error_description\":\"Insufficient " +
+                                         "scope for this resource\",\"scope\":\"uaa.admin orchestrator.zones.write zones.uaa.admin zones.write\"}",
                                          orchestratorClientZonesReadToken);
     }
 

--- a/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/OrchestratorZoneConfiguration.java
+++ b/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/OrchestratorZoneConfiguration.java
@@ -1,16 +1,14 @@
 package org.cloudfoundry.identity.uaa.zone;
 
+import org.cloudfoundry.identity.uaa.client.ClientAdminEndpointsValidator;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.cloudfoundry.identity.uaa.provider.IdentityProviderProvisioning;
-import org.cloudfoundry.identity.uaa.provider.IdentityProvider;
-import org.cloudfoundry.identity.uaa.provider.UaaIdentityProviderDefinition;
 import org.cloudfoundry.identity.uaa.scim.ScimGroupProvisioning;
 import org.cloudfoundry.identity.uaa.resources.QueryableResourceManager;
-import org.cloudfoundry.identity.uaa.client.ClientDetailsValidator;
 import org.springframework.security.oauth2.provider.ClientDetails;
 
 @Configuration
@@ -22,7 +20,7 @@ public class OrchestratorZoneConfiguration {
                                                            @Qualifier("identityProviderProvisioning") IdentityProviderProvisioning idpProvisioning,
                                                            @Qualifier("scimGroupProvisioning") ScimGroupProvisioning groupProvisioning,
                                                            @Qualifier("clientDetailsService") QueryableResourceManager<ClientDetails> clientDetailsService,
-                                                           @Qualifier("clientDetailsValidator") ClientDetailsValidator clientDetailsValidator,
+                                                           ClientAdminEndpointsValidator clientDetailsValidator,
                                                            @Value("${uaa.dashboard.uri}") String uaaDashboardUri,
                                                            @Value("${issuer.uri}") String uaaUrl) {
         return new OrchestratorZoneService(zoneProvisioning, idpProvisioning, groupProvisioning, clientDetailsService,

--- a/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/OrchestratorZoneService.java
+++ b/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/OrchestratorZoneService.java
@@ -29,8 +29,7 @@ import org.bouncycastle.openssl.jcajce.JcePEMEncryptorBuilder;
 import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.cloudfoundry.identity.uaa.audit.event.EntityDeletedEvent;
-import org.cloudfoundry.identity.uaa.client.ClientDetailsValidator;
-import org.cloudfoundry.identity.uaa.client.ClientDetailsValidator.Mode;
+import org.cloudfoundry.identity.uaa.client.ClientAdminEndpointsValidator;
 import org.cloudfoundry.identity.uaa.constants.OriginKeys;
 import org.cloudfoundry.identity.uaa.provider.IdentityProvider;
 import org.cloudfoundry.identity.uaa.provider.IdentityProviderProvisioning;
@@ -57,7 +56,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.common.util.RandomValueStringGenerator;
 import org.springframework.security.oauth2.provider.ClientDetails;
 import org.springframework.security.oauth2.provider.client.BaseClientDetails;
-import org.springframework.util.StringUtils;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 public class OrchestratorZoneService implements ApplicationEventPublisherAware {
@@ -81,7 +79,7 @@ public class OrchestratorZoneService implements ApplicationEventPublisherAware {
     private final IdentityProviderProvisioning idpProvisioning;
     private final ScimGroupProvisioning groupProvisioning;
     private final QueryableResourceManager<ClientDetails> clientDetailsService;
-    private final ClientDetailsValidator clientDetailsValidator;
+    private final ClientAdminEndpointsValidator clientDetailsValidator;
     private final String uaaDashboardUri;
     private final String domainName;
 
@@ -95,7 +93,7 @@ public class OrchestratorZoneService implements ApplicationEventPublisherAware {
                                    IdentityProviderProvisioning idpProvisioning,
                                    ScimGroupProvisioning groupProvisioning,
                                    QueryableResourceManager<ClientDetails> clientDetailsService,
-                                   ClientDetailsValidator clientDetailsValidator,
+                                   ClientAdminEndpointsValidator clientDetailsValidator,
                                    String uaaDashboardUri, String uaaUrl
                                   ) {
         this.zoneProvisioning = zoneProvisioning;
@@ -337,7 +335,7 @@ public class OrchestratorZoneService implements ApplicationEventPublisherAware {
                                        final String grantTypes, final String resourceIds, final String scopes) {
         BaseClientDetails clientDetails = new BaseClientDetails(clientId, resourceIds, scopes, grantTypes, authorities);
         clientDetails.setClientSecret(clientSecret);
-        ClientDetails details = clientDetailsValidator.validate(clientDetails, Mode.CREATE);
+        ClientDetails details = clientDetailsValidator.validate(clientDetails, true, false);
         clientDetailsService.create(details, id);
     }
 

--- a/zone-service/src/test/java/org/cloudfoundry/identity/uaa/zone/OrchestratorZoneServiceTests.java
+++ b/zone-service/src/test/java/org/cloudfoundry/identity/uaa/zone/OrchestratorZoneServiceTests.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -18,7 +19,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.cloudfoundry.identity.uaa.client.ClientDetailsValidator;
+import org.cloudfoundry.identity.uaa.client.ClientAdminEndpointsValidator;
 import org.cloudfoundry.identity.uaa.constants.OriginKeys;
 import org.cloudfoundry.identity.uaa.provider.IdentityProvider;
 import org.cloudfoundry.identity.uaa.provider.IdentityProviderProvisioning;
@@ -53,7 +54,7 @@ public class OrchestratorZoneServiceTests {
     private IdentityProviderProvisioning idpProvisioning;
     private ScimGroupProvisioning groupProvisioning;
     private QueryableResourceManager<ClientDetails> clientDetailsService;
-    private ClientDetailsValidator clientDetailsValidator;
+    private ClientAdminEndpointsValidator clientDetailsValidator;
 
     private final String serviceProviderKey =
         "-----BEGIN RSA PRIVATE KEY-----\n" +
@@ -108,7 +109,7 @@ public class OrchestratorZoneServiceTests {
         idpProvisioning = mock(IdentityProviderProvisioning.class);
         groupProvisioning = mock(ScimGroupProvisioning.class);
         clientDetailsService = mock(QueryableResourceManager.class);
-        clientDetailsValidator = mock(ClientDetailsValidator.class);
+        clientDetailsValidator = mock(ClientAdminEndpointsValidator.class);
         zoneService = new OrchestratorZoneService(zoneProvisioning, idpProvisioning, groupProvisioning,
                                                   clientDetailsService, clientDetailsValidator,
                                                   UAA_DASHBOARD_URI, DOMAIN_NAME);
@@ -195,7 +196,7 @@ public class OrchestratorZoneServiceTests {
                                 "Client Already exists exception not thrown");
         verify(idpProvisioning, times(1)).create(any(),any());
         verify(clientDetailsService, times(1)).create(any(),any());
-        verify(clientDetailsValidator, times(1)).validate(any(),any());
+        verify(clientDetailsValidator, times(1)).validate(any(),anyBoolean(),anyBoolean());
     }
 
     @Test
@@ -242,7 +243,7 @@ public class OrchestratorZoneServiceTests {
         verify(zoneProvisioning, times(1)).create(any());
         verify(idpProvisioning, times(1)).create(any(),any());
         verify(clientDetailsService, times(1)).create(any(),any());
-        verify(clientDetailsValidator, times(1)).validate(any(),any());
+        verify(clientDetailsValidator, times(1)).validate(any(),anyBoolean(),anyBoolean());
     }
 
     @Test


### PR DESCRIPTION
- Changed the multitenant-endpoints.xml for orchestrator zone api and add additional authorities in addition to standard uaa zone authorities. For GET API : orchestrator.zones.read POST / DELETE / PUT API : orchestrator.zones.write
- Updated mockmvc tests