### PR TITLE
Add default selfservice configs in orchestrator zone api

### DIFF
--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/OrchestratorZoneControllerIntegrationTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/OrchestratorZoneControllerIntegrationTests.java
@@ -547,13 +547,11 @@ public class OrchestratorZoneControllerIntegrationTests {
             adminClient.getForEntity(identityZoneURI, IdentityZone.class);
         LOGGER.info("Got identity zone: " + OBJECT_MAPPER.writeValueAsString(identityZoneResponse.getBody()));
         IdentityZoneConfiguration config = identityZoneResponse.getBody().getConfig();
-
-        // TODO validate below 2 gaps with team, these gaps found when compared service broker IT tests.
-        // For now commented below 2 assertions to avoid jenkins build and test pipeline build failure
-        // and it should be fixed as part of separate story with implementation related fixes in orchestrator post zone api.
-
-        // assertEquals(config.getLinks().getLogout().getWhitelist(), Collections.singletonList("http*://**." + runDomain));
-        // assertEquals(config.getLinks().getSelfService().getSignup(), "");
+        assertEquals(config.getLinks().getLogout().getWhitelist(),Collections.singletonList("http*://**"));
+        assertEquals(config.getLinks().getSelfService().isSelfServiceCreateAccountEnabled(), false);
+        assertEquals(config.getLinks().getSelfService().isSelfServiceResetPasswordEnabled(), true);
+        assertEquals(config.getLinks().getSelfService().getSignup(), "");
+        assertEquals(config.getLinks().getSelfService().getPasswd(), "/forgot_password");
         assertEquals(config.isIdpDiscoveryEnabled(), false);
         assertNotNull(config.getTokenPolicy().getActiveKeyId());
 

--- a/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/OrchestratorZoneService.java
+++ b/zone-service/src/main/java/org/cloudfoundry/identity/uaa/zone/OrchestratorZoneService.java
@@ -277,6 +277,9 @@ public class OrchestratorZoneService implements ApplicationEventPublisherAware {
         setTokenPolicy(createSigningKey(name), identityZone);
         setSamlConfig(identityZone);
         identityZone.getConfig().getLinks().getLogout().setWhitelist(createDeploymentSpecificLogoutWhiteList());
+        identityZone.getConfig().getLinks().getSelfService().setSelfServiceCreateAccountEnabled(false);
+        identityZone.getConfig().getLinks().getSelfService().setSignup("");
+        identityZone.getConfig().getLinks().getSelfService().setSelfServiceResetPasswordEnabled(true);
         return identityZone;
     }
 


### PR DESCRIPTION
- Zones created by orchestrator zone api have correct default values for signup and password fields.
- Un-commented test case asserts for the above cases

Ref Security broker IT tests:
[1] .  https://github.build.ge.com/predix/security-service-broker/blob/master/service-broker-it/src/test/java/com/ge/predix/integration/uaa/ServiceBrokerStepsDefinitions.java#L245-L246