### PR TITLE
Remove apt-get -qy install lsof from mock mvc test script

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -172,7 +172,6 @@ pipeline {
                             unset https_proxy
                             unset GRADLE_OPTS
                             pushd uaa
-                                apt-get -qy install lsof
                                 ./gradlew --no-daemon --continue jacocoRootReportUaaTest
                             popd
                             '''


### PR DESCRIPTION
Removed apt-get -qy install lsof from mock mvc test stage script

lsof means 'List Open Files'. On Linux servers,
Lsof command is used to find all files that are open by a process that is running on the server.

lists out all open files to the output console.

This command in not in use for mock mvc tests run.
Hence it is being removed from the jenkin mvc test stage script