### PR TITLE
Set image name in GESOS build request based on ECR environment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -517,13 +517,16 @@ pipeline {
             script {
                 if (params.TRIGGER_GESOS_IMAGE_BUILD && (BRANCH_NAME.matches('rc_[\\d.]+') || BRANCH_NAME.matches('release_[\\d.]+'))) {
                     imageTag = BRANCH_NAME
+                    ecrEnvironment = 'dev'
                     if (imageTag.matches('release_[\\d.]+')) {
                         imageTag = imageTag.replaceAll('release_', '')
+                        ecrEnvironment = 'stage'
                     }
             	    build job: JOB_NAME.replaceAll('/Build n Test/', '/GE SOS Build/'),
                     propagate: false,
                     wait: false,
                     parameters: [
+                        string(name: 'ECR_ENVIRONMENT', value: ecrEnvironment),
                         string(name: 'IAM_CONTAINER_CONFIG_BRANCH_NAME', value: BRANCH_NAME),
                         string(name: 'IMAGE_TAG', value: imageTag)
                     ]

--- a/gesos-image-build.pipeline
+++ b/gesos-image-build.pipeline
@@ -11,6 +11,11 @@ pipeline {
         }
     }
     parameters {
+        choice(
+            name: 'ECR_ENVIRONMENT',
+            choices:'dev\nstage\nprod',
+            description: 'ECR environment to publish image to'
+        )
         string(
             name: 'IAM_CONTAINER_CONFIG_BRANCH_NAME',
             defaultValue: BRANCH_NAME,
@@ -46,6 +51,12 @@ pipeline {
                     sh 'echo 10.229.23.137 gesos-apikey.gecloud.io >> /etc/hosts'
                     sh 'echo 10.229.23.151 gesos-apikey.gecloud.io >> /etc/hosts'
 
+                    if (params.ECR_ENVIRONMENT.matches('dev')) {
+                        IMAGE_NAME = 'iam-uaa'
+                    } else {
+                        IMAGE_NAME = "iam-${params.ECR_ENVIRONMENT}-uaa"
+                    }
+
                     result = sh(
                         script: """
                                     curl -sSL -X POST -H 'x-api-key: ${GESOS_API_KEY}' \\
@@ -55,7 +66,7 @@ pipeline {
                                                       "github_branch": "${params.IAM_CONTAINER_CONFIG_BRANCH_NAME}", \
                                                       "docker_folder": "./uaa", \
                                                       "pre_build_script":"pre-build.sh", \
-                                                      "image_name": "iam-uaa", \
+                                                      "image_name": "${IMAGE_NAME}", \
                                                       "contact_emails": "${API_BUILD_STATUS_EMAIL_RECIPIENTS}", \
                                                       "releaseTag1": "${params.IMAGE_TAG}", \
                                                       "release": "True" \


### PR DESCRIPTION
According to GESOS support, container image name should be unique across all products onboarded with GESOS for UAA images. Container image name chosen for UAA published in ECR in DEV environment is iam-uaa. Image name chosen for UAA in STAGE environment is iam-stage-uaa.

In Jenkins, use ECR environment to make container image name unique.

- Add a parameter to gesos-image-build.pipeline to specify ECR environment to publish UAA image to. When triggering a build in GESOS, set container image name based on the environment.
- Modify Jenkins file to pass ECR environment parameter when triggering GESOS build. For rc branch trigger GESOS build for DEV environment; for release branch trigger GESOS build for STAGE environment.