### PR TITLE
Federated login test for orchestrator provisioned zone

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -216,7 +216,7 @@ pipeline {
                         docker {
                             image "${NODE['IMAGE']}"
                             label "${NODE['LABEL']}"
-                            args '-v /var/lib/docker/.gradle:/root/.gradle --add-host "zone-with-cors-policy.localhost testzone1.localhost testzone2.localhost int-test-zone-uaa.localhost testzone3.localhost testzone4.localhost testzonedoesnotexist.localhost testzoneinactive.localhost oidcloginit.localhost test-zone1.localhost test-zone2.localhost test-victim-zone.localhost test-platform-zone.localhost test-saml-zone.localhost test-app-zone.localhost app-zone.localhost platform-zone.localhost testsomeother2.ip.com testsomeother.ip.com uaa-acceptance-zone.localhost orchestrator-int-test-zone.localhost localhost":127.0.0.1'
+                            args '-v /var/lib/docker/.gradle:/root/.gradle --add-host "zone-with-cors-policy.localhost testzone1.localhost testzone2.localhost int-test-zone-uaa.localhost testzone3.localhost testzone4.localhost testzonedoesnotexist.localhost testzoneinactive.localhost oidcloginit.localhost test-zone1.localhost test-zone2.localhost test-victim-zone.localhost test-platform-zone.localhost test-saml-zone.localhost test-app-zone.localhost app-zone.localhost platform-zone.localhost testsomeother2.ip.com testsomeother.ip.com uaa-acceptance-zone.localhost orchestrator-int-test-zone.localhost localhost samlidpzone.localhost samlspzone.localhost":127.0.0.1'
                         }
                     }
                     steps {

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlBaseIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlBaseIT.java
@@ -1,0 +1,167 @@
+package org.cloudfoundry.identity.uaa.integration.feature;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.apache.commons.lang.StringUtils;
+import org.cloudfoundry.identity.uaa.ServerRunning;
+import org.cloudfoundry.identity.uaa.constants.OriginKeys;
+import org.cloudfoundry.identity.uaa.integration.util.IntegrationTestUtils;
+import org.cloudfoundry.identity.uaa.provider.IdentityProvider;
+import org.cloudfoundry.identity.uaa.provider.SamlIdentityProviderDefinition;
+import org.cloudfoundry.identity.uaa.provider.saml.idp.SamlServiceProvider;
+import org.cloudfoundry.identity.uaa.provider.saml.idp.SamlServiceProviderDefinition;
+import org.cloudfoundry.identity.uaa.provider.saml.idp.SamlTestUtils;
+import org.cloudfoundry.identity.uaa.util.JsonUtils;
+import org.cloudfoundry.identity.uaa.zone.IdentityZoneSwitchingFilter;
+import org.openqa.selenium.WebDriver;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import java.util.List;
+import static org.junit.Assert.assertNotNull;
+
+@ContextConfiguration(classes = DefaultIntegrationTestConfig.class)
+public class SamlBaseIT {
+
+    @Value("${integration.test.base_url}")
+    String baseUrl;
+
+    public static final String IDP_ENTITY_ID = "cloudfoundry-saml-login";
+
+    ServerRunning serverRunning = ServerRunning.isRunning();
+
+    protected final SamlTestUtils samlTestUtils = new SamlTestUtils();
+
+    @Autowired
+    WebDriver webDriver;
+
+    protected RestTemplate getIdentityClient() {
+        return IntegrationTestUtils.getClientCredentialsTemplate(
+                IntegrationTestUtils.getClientCredentialsResource(
+                        baseUrl, new String[]{"zones.write", "zones.read", "scim.zones"}, "identity", "identitysecret")
+        );
+    }
+
+
+
+    public static SamlIdentityProviderDefinition createLocalSamlIdpDefinition(String alias, String zoneId) {
+        String url;
+        if (StringUtils.isNotEmpty(zoneId) && !zoneId.equals("uaa")) {
+            url = "http://" + zoneId + ".localhost:8080/uaa/saml/idp/metadata";
+        } else {
+            url = "http://localhost:8080/uaa/saml/idp/metadata";
+        }
+        String idpMetaData = getIdpMetadata(url);
+        return SamlTestUtils.createLocalSamlIdpDefinition(alias, zoneId, idpMetaData);
+    }
+
+    public static String getIdpMetadata(String url) {
+        RestTemplate client = new RestTemplate();
+        MultiValueMap<String, String> headers = new LinkedMultiValueMap<>();
+        headers.add("Accept", "application/samlmetadata+xml");
+        HttpEntity<String> getHeaders = new HttpEntity<>(headers);
+        ResponseEntity<String> metadataResponse = client.exchange(url, HttpMethod.GET, getHeaders, String.class);
+
+        return metadataResponse.getBody();
+    }
+
+    protected IdentityProvider<SamlIdentityProviderDefinition> getSamlIdentityProvider(String spZoneId, String spZoneAdminToken, SamlIdentityProviderDefinition samlIdentityProviderDefinition) {
+        IdentityProvider<SamlIdentityProviderDefinition> idp = new IdentityProvider<>();
+        idp.setIdentityZoneId(spZoneId);
+        idp.setType(OriginKeys.SAML);
+        idp.setActive(true);
+        idp.setConfig(samlIdentityProviderDefinition);
+        idp.setOriginKey(samlIdentityProviderDefinition.getIdpEntityAlias());
+        idp.setName("Local SAML IdP for samlidpzone");
+        idp = IntegrationTestUtils.createOrUpdateProvider(spZoneAdminToken, baseUrl, idp);
+        assertNotNull(idp.getId());
+        return idp;
+    }
+
+    protected SamlServiceProvider getSamlServiceProvider(String idpZoneId, String idpZoneAdminToken, SamlServiceProviderDefinition samlServiceProviderDefinition, String entityId, String local_saml_sp_for_testzone2, String baseUrl) {
+        SamlServiceProvider sp = new SamlServiceProvider();
+        sp.setIdentityZoneId(idpZoneId);
+        sp.setActive(true);
+        sp.setConfig(samlServiceProviderDefinition);
+        sp.setEntityId(entityId);
+        sp.setName(local_saml_sp_for_testzone2);
+        sp = createOrUpdateSamlServiceProvider(idpZoneAdminToken, baseUrl, sp);
+        return sp;
+    }
+
+
+
+    public static SamlServiceProviderDefinition createLocalSamlSpDefinition(String alias, String zoneId) {
+
+        String url;
+        if (StringUtils.isNotEmpty(zoneId) && !zoneId.equals("uaa")) {
+            url = "http://" + zoneId + ".localhost:8080/uaa/saml/metadata/alias/" + zoneId + "." + alias;
+        } else {
+            url = "http://localhost:8080/uaa/saml/metadata/alias/" + alias;
+        }
+
+        String spMetaData = getIdpMetadata(url);
+        SamlServiceProviderDefinition def = new SamlServiceProviderDefinition();
+        def.setMetaDataLocation(spMetaData);
+        def.setNameID("urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress");
+        def.setSingleSignOnServiceIndex(0);
+        def.setMetadataTrustCheck(false);
+        def.setEnableIdpInitiatedSso(true);
+        return def;
+    }
+
+    public static SamlServiceProvider createOrUpdateSamlServiceProvider(String accessToken, String url,
+                                                                        SamlServiceProvider provider) {
+        RestTemplate client = new RestTemplate();
+        MultiValueMap<String, String> headers = new LinkedMultiValueMap<>();
+        headers.add("Accept", MediaType.APPLICATION_JSON_VALUE);
+        headers.add("Authorization", "bearer " + accessToken);
+        headers.add("Content-Type", MediaType.APPLICATION_JSON_VALUE);
+        headers.add(IdentityZoneSwitchingFilter.HEADER, provider.getIdentityZoneId());
+        List<SamlServiceProvider> existing = getSamlServiceProviders(accessToken, url, provider.getIdentityZoneId());
+        if (existing != null) {
+            for (SamlServiceProvider p : existing) {
+                if (p.getEntityId().equals(provider.getEntityId())
+                        && p.getIdentityZoneId().equals(provider.getIdentityZoneId())) {
+                    provider.setId(p.getId());
+                    HttpEntity<SamlServiceProvider> putHeaders = new HttpEntity<SamlServiceProvider>(provider, headers);
+                    ResponseEntity<String> providerPut = client.exchange(url + "/saml/service-providers/{id}",
+                            HttpMethod.PUT, putHeaders, String.class, provider.getId());
+                    if (providerPut.getStatusCode() == HttpStatus.OK) {
+                        return JsonUtils.readValue(providerPut.getBody(), SamlServiceProvider.class);
+                    }
+                }
+            }
+        }
+
+        HttpEntity<SamlServiceProvider> postHeaders = new HttpEntity<SamlServiceProvider>(provider, headers);
+        ResponseEntity<String> providerPost = client.exchange(url + "/saml/service-providers/{id}", HttpMethod.POST,
+                postHeaders, String.class, provider.getId());
+        if (providerPost.getStatusCode() == HttpStatus.CREATED) {
+            return JsonUtils.readValue(providerPost.getBody(), SamlServiceProvider.class);
+        }
+        throw new IllegalStateException(
+                "Invalid result code returned, unable to create identity provider:" + providerPost.getStatusCode());
+    }
+
+    public static List<SamlServiceProvider> getSamlServiceProviders(String zoneAdminToken, String url, String zoneId) {
+        RestTemplate client = new RestTemplate();
+        MultiValueMap<String, String> headers = new LinkedMultiValueMap<>();
+        headers.add("Accept", MediaType.APPLICATION_JSON_VALUE);
+        headers.add("Authorization", "bearer " + zoneAdminToken);
+        headers.add("Content-Type", MediaType.APPLICATION_JSON_VALUE);
+        headers.add(IdentityZoneSwitchingFilter.HEADER, zoneId);
+        HttpEntity<String> getHeaders = new HttpEntity<String>(headers);
+        ResponseEntity<String> providerGet = client.exchange(url + "/saml/service-providers", HttpMethod.GET, getHeaders,
+                String.class);
+        if (providerGet != null && providerGet.getStatusCode() == HttpStatus.OK) {
+            return JsonUtils.readValue(providerGet.getBody(), new TypeReference<List<SamlServiceProvider>>() {
+                // Do nothing.
+            });
+        }
+        return null;
+    }
+}

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginForOrchestratorZoneIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginForOrchestratorZoneIT.java
@@ -1,0 +1,147 @@
+package org.cloudfoundry.identity.uaa.integration.feature;
+
+
+import org.cloudfoundry.identity.uaa.integration.feature.orchestrator.uilocators.IdploginUI;
+import org.cloudfoundry.identity.uaa.integration.feature.orchestrator.uilocators.SploginUI;
+import org.cloudfoundry.identity.uaa.integration.feature.orchestrator.utils.IntegrationUtilsOrchestrator;
+import org.cloudfoundry.identity.uaa.integration.util.IntegrationTestUtils;
+import org.cloudfoundry.identity.uaa.provider.SamlIdentityProviderDefinition;
+import org.cloudfoundry.identity.uaa.provider.saml.idp.SamlServiceProviderDefinition;
+import org.cloudfoundry.identity.uaa.scim.ScimGroup;
+import org.cloudfoundry.identity.uaa.scim.ScimUser;
+import org.cloudfoundry.identity.uaa.zone.IdentityZone;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.openqa.selenium.By;
+import org.openqa.selenium.Cookie;
+import org.openqa.selenium.NoSuchElementException;
+import org.springframework.security.oauth2.common.util.RandomValueStringGenerator;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.web.client.RestTemplate;
+import java.net.Inet4Address;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import static org.junit.Assert.*;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = DefaultIntegrationTestConfig.class)
+public class SamlLoginForOrchestratorZoneIT extends SamlBaseIT {
+
+
+    @Before
+    public void clearWebDriverOfCookies() throws Exception {
+        samlTestUtils.initialize();
+        webDriver.get(baseUrl + "/logout.do");
+        webDriver.manage().deleteAllCookies();
+        webDriver.get(baseUrl.replace("localhost", "samlidpzone.localhost") + "/logout.do");
+        webDriver.manage().deleteAllCookies();
+        webDriver.get(baseUrl.replace("localhost", "samlspzone.localhost") + "/logout.do");
+        webDriver.manage().deleteAllCookies();
+        assertTrue("Expected samlidpzone.localhost and samlspzone.localhost to resolve to 127.0.0.1", doesSupportZoneDNS());
+    }
+
+    @Before
+    public void setup() {
+        String token = IntegrationTestUtils.getClientCredentialsToken(baseUrl, "admin", "adminsecret");
+
+        ScimGroup group = new ScimGroup(null, "zones.samlidpzone.admin", null);
+        IntegrationTestUtils.createGroup(token, "", baseUrl, group);
+
+        group = new ScimGroup(null, "zones.samlspzone.admin", null);
+        IntegrationTestUtils.createGroup(token, "", baseUrl, group);
+
+        group = new ScimGroup(null, "zones.uaa.admin", null);
+        IntegrationTestUtils.createGroup(token, "", baseUrl, group);
+    }
+
+    protected boolean doesSupportZoneDNS() {
+        try {
+            return Arrays.equals(Inet4Address.getByName("samlidpzone.localhost").getAddress(),
+                    new byte[]{127, 0, 0, 1})
+                    && Arrays.equals(Inet4Address.getByName("samlspzone.localhost").getAddress(),
+                    new byte[]{127, 0, 0, 1});
+        } catch (UnknownHostException e) {
+            return false;
+        }
+    }
+
+    /**
+     * In this test samlidpzone acts as the SAML IdP and samlspzone acts as the SAML SP.
+     */
+    @Test
+    public void testCrossZoneSamlIntegration() throws Throwable {
+        String idpZoneId = "samlidpzone";
+        String idpZoneUrl = baseUrl.replace("localhost", idpZoneId + ".localhost");
+        String spZoneId = "samlspzone";
+        String spZoneUrl = baseUrl.replace("localhost", spZoneId + ".localhost");
+        RestTemplate orchestratorZoneProvisioner = getIdentityClient();
+        //Creating Orch IDP Zone
+        IdentityZone idpZone = IntegrationUtilsOrchestrator.createOrchZone(orchestratorZoneProvisioner, baseUrl, idpZoneId, idpZoneId);
+        String idpZoneUserEmail = new RandomValueStringGenerator().generate() + "@samltesting.org";
+        //Create user for IDP Admin
+        createZoneUser(idpZoneId, idpZoneUserEmail, idpZoneUrl);
+        //Creating Orch SP Zone
+        IdentityZone spZone = IntegrationUtilsOrchestrator.createOrchZone(orchestratorZoneProvisioner, baseUrl, spZoneId, spZoneId);
+        //Get Client credentials for SP Admin token
+        String spZoneAdminToken = IntegrationTestUtils.getClientCredentialsToken(serverRunning, "admin", "adminsecret");
+        //Get IDP Metadata
+        SamlIdentityProviderDefinition samlIdentityProviderDefinition = createZone1IdpDefinition(IDP_ENTITY_ID);
+        // Create IDP
+        getSamlIdentityProvider(spZone.getId(), spZoneAdminToken, samlIdentityProviderDefinition);
+        //Get SP Metadata
+        SamlServiceProviderDefinition samlServiceProviderDefinition = createZone2SamlSpDefinition("cloudfoundry-saml-login");
+        // Create SP
+        getSamlServiceProvider(idpZone.getId(), spZoneAdminToken, samlServiceProviderDefinition, "samlspzone.cloudfoundry-saml-login", "Local SAML SP for samlspzone", baseUrl);
+        //Login into SP with IDP credentials
+        performLogin(idpZoneUserEmail,spZone, spZoneUrl);
+        webDriver.get(baseUrl + "/logout.do");
+        webDriver.get(spZoneUrl + "/logout.do");
+    }
+
+    public static SamlServiceProviderDefinition createZone2SamlSpDefinition(String alias) {
+        return createLocalSamlSpDefinition(alias, "samlspzone");
+    }
+
+    public SamlIdentityProviderDefinition createZone1IdpDefinition(String alias) {
+        return createLocalSamlIdpDefinition(alias, "samlidpzone");
+    }
+
+    private ScimUser createZoneUser(String idpZoneId, String zoneUserEmail, String zoneUrl) {
+        RestTemplate zoneAdminClient = IntegrationTestUtils.getClientCredentialsTemplate(IntegrationTestUtils
+                .getClientCredentialsResource(zoneUrl, new String[0], "admin", "adminsecret"));
+        return IntegrationTestUtils.createUserWithPhone(zoneAdminClient, zoneUrl, zoneUserEmail, "Dana", "Scully", zoneUserEmail,
+                true, "1234567890");
+    }
+
+    public void performLogin(String idpZoneUserEmail,IdentityZone spZone, String spZoneUrl) {
+        IdploginUI ssoIdp = new IdploginUI(webDriver);
+        SploginUI ssoSp = new SploginUI(webDriver);
+        webDriver.get(spZoneUrl + "/");
+        assertEquals(spZone.getName(), webDriver.getTitle());
+        Cookie beforeLogin = webDriver.manage().getCookieNamed("JSESSIONID");
+        assertNotNull(beforeLogin);
+        assertNotNull(beforeLogin.getValue());
+        ssoSp.clickOnSignInByGesso();
+        try {
+
+            ssoIdp.headLineCheck();
+
+            ssoIdp.enterIDPuserName(idpZoneUserEmail);
+
+            ssoIdp.enterIDPPassword("secr3T");
+
+            ssoIdp.clickOnSignIn();
+            assertThat(webDriver.findElement(By.cssSelector("h1")).getText(), Matchers.containsString("You should not see this page. Set up your redirect URI."));
+            Cookie afterLogin = webDriver.manage().getCookieNamed("JSESSIONID");
+            assertNotNull(afterLogin);
+            assertNotNull(afterLogin.getValue());
+            assertNotEquals(beforeLogin.getValue(), afterLogin.getValue());
+        } catch (Exception e) {
+            assertTrue("Http-Artifact binding is not supported", e instanceof NoSuchElementException);
+
+        }
+    }
+}

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginWithLocalIdpIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginWithLocalIdpIT.java
@@ -18,7 +18,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import org.apache.commons.lang.StringUtils;
 import org.cloudfoundry.identity.uaa.ServerRunning;
 import org.cloudfoundry.identity.uaa.constants.OriginKeys;
 import org.cloudfoundry.identity.uaa.integration.util.IntegrationTestUtils;
@@ -48,11 +47,9 @@ import org.junit.runner.RunWith;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Cookie;
 import org.openqa.selenium.NoSuchElementException;
-import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.opensaml.saml2.metadata.IDPSSODescriptor;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -94,11 +91,8 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = DefaultIntegrationTestConfig.class)
-public class SamlLoginWithLocalIdpIT {
+    public class SamlLoginWithLocalIdpIT extends SamlBaseIT {
 
-    public static final String IDP_ENTITY_ID = "cloudfoundry-saml-login";
-
-    private final SamlTestUtils samlTestUtils = new SamlTestUtils();
     @Autowired
     @Rule
     public IntegrationTestRule integrationTestRule;
@@ -107,18 +101,10 @@ public class SamlLoginWithLocalIdpIT {
     RestOperations restOperations;
 
     @Autowired
-    WebDriver webDriver;
-
-    @Value("${integration.test.base_url}")
-    String baseUrl;
-
-    @Autowired
     TestAccounts testAccounts;
 
     @Autowired
     TestClient testClient;
-
-    ServerRunning serverRunning = ServerRunning.isRunning();
 
     @Before
     public void clearWebDriverOfCookies() throws Exception {
@@ -828,17 +814,12 @@ public class SamlLoginWithLocalIdpIT {
         assertEquals(1, elements.size());
     }
 
-    private IdentityProvider<SamlIdentityProviderDefinition> getSamlIdentityProvider(String spZoneId, String spZoneAdminToken, SamlIdentityProviderDefinition samlIdentityProviderDefinition) {
-        IdentityProvider<SamlIdentityProviderDefinition> idp = new IdentityProvider<>();
-        idp.setIdentityZoneId(spZoneId);
-        idp.setType(OriginKeys.SAML);
-        idp.setActive(true);
-        idp.setConfig(samlIdentityProviderDefinition);
-        idp.setOriginKey(samlIdentityProviderDefinition.getIdpEntityAlias());
-        idp.setName("Local SAML IdP for testzone1");
-        idp = IntegrationTestUtils.createOrUpdateProvider(spZoneAdminToken, baseUrl, idp);
-        assertNotNull(idp.getId());
-        return idp;
+    public static SamlServiceProviderDefinition createZone2SamlSpDefinition(String alias) {
+        return createLocalSamlSpDefinition(alias, "testzone2");
+    }
+
+    public SamlIdentityProviderDefinition createZone1IdpDefinition(String alias) {
+        return createLocalSamlIdpDefinition(alias, "testzone1");
     }
 
     private void testLocalSamlIdpLogin(String firstUrl, String lookfor, String username, String password)
@@ -896,15 +877,6 @@ public class SamlLoginWithLocalIdpIT {
         client.exchange(url + "/saml/service-providers/" + id , HttpMethod.DELETE, deleteHeaders, String.class);
     }
 
-    private void getSamlServiceProvider(String idpZoneId, String idpZoneAdminToken, SamlServiceProviderDefinition samlServiceProviderDefinition, String entityId, String local_saml_sp_for_testzone2, String baseUrl) {
-        SamlServiceProvider sp = new SamlServiceProvider();
-        sp.setIdentityZoneId(idpZoneId);
-        sp.setActive(true);
-        sp.setConfig(samlServiceProviderDefinition);
-        sp.setEntityId(entityId);
-        sp.setName(local_saml_sp_for_testzone2);
-        sp = createOrUpdateSamlServiceProvider(idpZoneAdminToken, baseUrl, sp);
-    }
 
     private ScimUser getSpZoneAdminUser(RestTemplate adminClient, String spZoneAdminEmail) {
         return IntegrationTestUtils.createUser(
@@ -922,13 +894,6 @@ public class SamlLoginWithLocalIdpIT {
         return IntegrationTestUtils.getClientCredentialsTemplate(
             IntegrationTestUtils.getClientCredentialsResource(
                 baseUrl, new String[0], "admin", "adminsecret")
-        );
-    }
-
-    private RestTemplate getIdentityClient() {
-        return IntegrationTestUtils.getClientCredentialsTemplate(
-            IntegrationTestUtils.getClientCredentialsResource(
-                baseUrl,new String[]{"zones.write", "zones.read", "scim.zones"}, "identity", "identitysecret")
         );
     }
 
@@ -1023,9 +988,6 @@ public class SamlLoginWithLocalIdpIT {
         }
     }
 
-    public SamlIdentityProviderDefinition createZone1IdpDefinition(String alias) {
-        return createLocalSamlIdpDefinition(alias, "testzone1");
-    }
 
     public SamlIdentityProviderDefinition createZone2IdpDefinition(String alias) {
         return createLocalSamlIdpDefinition(alias, "testzone2");
@@ -1035,52 +997,8 @@ public class SamlLoginWithLocalIdpIT {
         return createLocalSamlIdpDefinition(alias, "testzone3");
     }
 
-    public static SamlIdentityProviderDefinition createLocalSamlIdpDefinition(String alias, String zoneId) {
-        String url;
-        if (StringUtils.isNotEmpty(zoneId) && !zoneId.equals("uaa")) {
-            url = "http://" + zoneId + ".localhost:8080/uaa/saml/idp/metadata";
-        } else {
-            url = "http://localhost:8080/uaa/saml/idp/metadata";
-        }
-        String idpMetaData = getIdpMetadata(url);
-        return SamlTestUtils.createLocalSamlIdpDefinition(alias, zoneId, idpMetaData);
-    }
-
-    public static String getIdpMetadata(String url) {
-        RestTemplate client = new RestTemplate();
-        MultiValueMap<String, String> headers = new LinkedMultiValueMap<>();
-        headers.add("Accept", "application/samlmetadata+xml");
-        HttpEntity<String> getHeaders = new HttpEntity<>(headers);
-        ResponseEntity<String> metadataResponse = client.exchange(url, HttpMethod.GET, getHeaders, String.class);
-
-        return metadataResponse.getBody();
-    }
-
-    public static SamlServiceProviderDefinition createLocalSamlSpDefinition(String alias, String zoneId) {
-
-        String url;
-        if (StringUtils.isNotEmpty(zoneId) && !zoneId.equals("uaa")) {
-            url = "http://" + zoneId + ".localhost:8080/uaa/saml/metadata/alias/" + zoneId + "." + alias;
-        } else {
-            url = "http://localhost:8080/uaa/saml/metadata/alias/" + alias;
-        }
-
-        String spMetaData = getIdpMetadata(url);
-        SamlServiceProviderDefinition def = new SamlServiceProviderDefinition();
-        def.setMetaDataLocation(spMetaData);
-        def.setNameID("urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress");
-        def.setSingleSignOnServiceIndex(0);
-        def.setMetadataTrustCheck(false);
-        def.setEnableIdpInitiatedSso(true);
-        return def;
-    }
-
     public static SamlServiceProviderDefinition createZone1SamlSpDefinition(String alias) {
         return createLocalSamlSpDefinition(alias, "testzone1");
-    }
-
-    public static SamlServiceProviderDefinition createZone2SamlSpDefinition(String alias) {
-        return createLocalSamlSpDefinition(alias, "testzone2");
     }
 
     public static SamlServiceProvider createSamlServiceProvider(String name, String entityId, String baseUrl,
@@ -1107,57 +1025,4 @@ public class SamlLoginWithLocalIdpIT {
         assertNotNull(provider.getId());
         return provider;
     }
-
-    public static SamlServiceProvider createOrUpdateSamlServiceProvider(String accessToken, String url,
-                                                                        SamlServiceProvider provider) {
-        RestTemplate client = new RestTemplate();
-        MultiValueMap<String, String> headers = new LinkedMultiValueMap<>();
-        headers.add("Accept", MediaType.APPLICATION_JSON_VALUE);
-        headers.add("Authorization", "bearer " + accessToken);
-        headers.add("Content-Type", MediaType.APPLICATION_JSON_VALUE);
-        headers.add(IdentityZoneSwitchingFilter.HEADER, provider.getIdentityZoneId());
-        List<SamlServiceProvider> existing = getSamlServiceProviders(accessToken, url, provider.getIdentityZoneId());
-        if (existing != null) {
-            for (SamlServiceProvider p : existing) {
-                if (p.getEntityId().equals(provider.getEntityId())
-                  && p.getIdentityZoneId().equals(provider.getIdentityZoneId())) {
-                    provider.setId(p.getId());
-                    HttpEntity<SamlServiceProvider> putHeaders = new HttpEntity<SamlServiceProvider>(provider, headers);
-                    ResponseEntity<String> providerPut = client.exchange(url + "/saml/service-providers/{id}",
-                      HttpMethod.PUT, putHeaders, String.class, provider.getId());
-                    if (providerPut.getStatusCode() == HttpStatus.OK) {
-                        return JsonUtils.readValue(providerPut.getBody(), SamlServiceProvider.class);
-                    }
-                }
-            }
-        }
-
-        HttpEntity<SamlServiceProvider> postHeaders = new HttpEntity<SamlServiceProvider>(provider, headers);
-        ResponseEntity<String> providerPost = client.exchange(url + "/saml/service-providers/{id}", HttpMethod.POST,
-          postHeaders, String.class, provider.getId());
-        if (providerPost.getStatusCode() == HttpStatus.CREATED) {
-            return JsonUtils.readValue(providerPost.getBody(), SamlServiceProvider.class);
-        }
-        throw new IllegalStateException(
-          "Invalid result code returned, unable to create identity provider:" + providerPost.getStatusCode());
-    }
-
-    public static List<SamlServiceProvider> getSamlServiceProviders(String zoneAdminToken, String url, String zoneId) {
-        RestTemplate client = new RestTemplate();
-        MultiValueMap<String, String> headers = new LinkedMultiValueMap<>();
-        headers.add("Accept", MediaType.APPLICATION_JSON_VALUE);
-        headers.add("Authorization", "bearer " + zoneAdminToken);
-        headers.add("Content-Type", MediaType.APPLICATION_JSON_VALUE);
-        headers.add(IdentityZoneSwitchingFilter.HEADER, zoneId);
-        HttpEntity<String> getHeaders = new HttpEntity<String>(headers);
-        ResponseEntity<String> providerGet = client.exchange(url + "/saml/service-providers", HttpMethod.GET, getHeaders,
-          String.class);
-        if (providerGet != null && providerGet.getStatusCode() == HttpStatus.OK) {
-            return JsonUtils.readValue(providerGet.getBody(), new TypeReference<List<SamlServiceProvider>>() {
-                // Do nothing.
-            });
-        }
-        return null;
-    }
-
 }

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/orchestrator/uilocators/IdploginUI.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/orchestrator/uilocators/IdploginUI.java
@@ -1,0 +1,36 @@
+package org.cloudfoundry.identity.uaa.integration.feature.orchestrator.uilocators;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+
+public class IdploginUI {
+    WebDriver driver;
+
+    public IdploginUI(WebDriver driver) {
+        this.driver = driver;
+    }
+
+    By IDPUserName = By.xpath("//input[@name='username']");
+    By IDPPassword = By.xpath("//input[@name='password']");
+    By clickOnSignIn = By.xpath("//input[@value='Sign in']");
+    By welcomecheck = By.xpath("//h1[contains(text(), 'Welcome to testzone1!')]");
+
+    public void enterIDPuserName(String EnterIDPuserName) {
+        driver.findElement(IDPUserName).sendKeys(EnterIDPuserName);
+    }
+
+    public void enterIDPPassword(String enterIDPPassword) {
+        driver.findElement(IDPPassword).sendKeys(enterIDPPassword);
+    }
+
+    public void clickOnSignIn() {
+        driver.findElement(clickOnSignIn).click();
+    }
+
+
+    public void headLineCheck() {
+        driver.findElement(welcomecheck).click();
+    }
+}
+
+

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/orchestrator/uilocators/SploginUI.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/orchestrator/uilocators/SploginUI.java
@@ -1,0 +1,21 @@
+package org.cloudfoundry.identity.uaa.integration.feature.orchestrator.uilocators;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+
+public class SploginUI {
+    WebDriver driver;
+
+    public SploginUI(WebDriver driver) {
+        this.driver = driver;
+    }
+
+    By Gesso = By.xpath("//a[@class='saml-login-link']");
+
+
+    public void clickOnSignInByGesso() {
+        driver.findElement(Gesso).click();
+    }
+
+
+}

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/orchestrator/utils/IntegrationUtilsOrchestrator.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/orchestrator/utils/IntegrationUtilsOrchestrator.java
@@ -1,0 +1,43 @@
+package org.cloudfoundry.identity.uaa.integration.feature.orchestrator.utils;
+
+import org.cloudfoundry.identity.uaa.zone.IdentityZone;
+import org.cloudfoundry.identity.uaa.zone.model.OrchestratorZone;
+import org.cloudfoundry.identity.uaa.zone.model.OrchestratorZoneRequest;
+import org.cloudfoundry.identity.uaa.zone.model.OrchestratorZoneResponse;
+import org.springframework.http.*;
+import org.springframework.web.client.RestTemplate;
+
+public class IntegrationUtilsOrchestrator {
+
+    private static IdentityZone createOrchZone(RestTemplate client,
+                                               String url,
+                                               String id,
+                                               String subdomain,
+                                               boolean active) throws Throwable {
+        OrchestratorZoneRequest orchestratorZoneRequest = new OrchestratorZoneRequest();
+        orchestratorZoneRequest.setName(id);
+        orchestratorZoneRequest.setParameters(new OrchestratorZone("adminsecret", subdomain));
+        //Create orch zone
+        client.postForEntity(url + "/orchestrator/zones", orchestratorZoneRequest, OrchestratorZoneResponse.class);
+        //Get orch zone
+        ResponseEntity<OrchestratorZoneResponse> orchestratorZone = client.getForEntity(url + "/orchestrator/zones?name=" + id, OrchestratorZoneResponse.class, id);
+        //Retrieve Zone ID for Identity Zone from orch Header
+        OrchestratorZoneResponse getZoneResponse = orchestratorZone.getBody();
+        final String zoneId = getZoneResponse.getConnectionDetails().getZone().getHttpHeaderValue();
+        //Retrieve
+        ResponseEntity<IdentityZone> nativeZone = client.getForEntity(url + "/identity-zones/" + zoneId, IdentityZone.class, id);
+        return nativeZone.getBody();
+    }
+
+
+    public static IdentityZone createOrchZone(RestTemplate client,
+                                              String url,
+                                              String id,
+                                              String subdomain
+                                                 ) throws Throwable {
+        return createOrchZone(client, url, id, subdomain, true);
+    }
+
+
+
+}


### PR DESCRIPTION
Add integration test for federated login through orchestrator where the SP and IDP are created with metadata integration. and create a IDP user. Provisioning the SP and IDP Zones before performing login and checking the login flow through headless chrome browser.