### PR TITLE
Refactor OrchestratorZoneControllerIntegrationTests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -413,51 +413,6 @@ pipeline {
                 }
             }
         }
-        stage('Build PR image and publish to ECR') {
-            when {
-                // Image build and push for rc and release branches is done using GE SOS Build pipeline
-                // See gesos-image-build.pipeline triggered using Post-Build Script stage
-                changeRequest()
-            }
-            agent {
-                docker {
-                    image "${NODE['IMAGE']}"
-                    label "${NODE['LABEL']}"
-                    args "${NODE['ARGS']} -v /var/run/docker.sock:/var/run/docker.sock"
-                }
-            }
-            environment {
-                AWS_ECR_SSO_CREDENTIALS = credentials('AWS_ECR_SSO_CREDENTIALS')
-            }
-            steps {
-                dir('iam-container-config') {
-                    // Check out repo with Dockerfiles and build/publish script
-                    git changelog: false,
-                            credentialsId: 'github.build.ge.com',
-                            poll: false,
-                            url: 'https://github.build.ge.com/predix/iam-container-config.git',
-                            branch: 'master'
-
-                    unstash 'uaa-war'
-                    script {
-                        sh """
-                            # Copy war file for copying into container image when building
-                            cp cloudfoundry-identity-uaa*.war uaa/cloudfoundry-identity-uaa.war
-
-                            ./container-build-publish uaa
-                        """
-                    }
-                }
-            }
-            post {
-                success {
-                    echo "Build PR image and publish to ECR completed"
-                }
-                failure {
-                    echo "Build PR image and publish to ECR failed"
-                }
-            }
-        }
         stage('Upload Build Artifact') {
             agent {
                 label 'dind'


### PR DESCRIPTION
In testCreateZone_WithZoneConfigValidation():
- Use super admin client credentials to retrieve native zone
- Use zone admin client credentials to retrieve client details, configuration, and default identity provider configuration for new zone
- Use zone admin client to validate zone /token_key and /check_token endpoints