### PR TITLE
Provide artifactory credentials to download dependencies for scanning

### DIFF
--- a/AnalysisJenkinsfile
+++ b/AnalysisJenkinsfile
@@ -5,6 +5,9 @@ pipeline {
     triggers {
         cron('H 22 1 * *')
     }
+    environment {
+        ARTIFACTORY_CREDENTIALS = credentials("DIGITAL_GRID_ARTIFACTORY_CREDENTIALS")
+    }
     options {
         timestamps()
         skipDefaultCheckout()


### PR DESCRIPTION
We are using GE Digital Artifactory to manage dependencies. Credentials are required to download dependencies from artifactory during Coverity and Whitesource scans.