### PR TITLE
Remove asciidoctor-gradle-plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,6 @@ buildscript {
 
     dependencies {
         classpath(libraries.cargoGradlePlugin)
-        classpath(libraries.asciidoctorGradlePlugin)
         classpath(libraries.springDependencyMangementGradlePlugin)
         classpath(libraries.springBootGradlePlugin)
         classpath(libraries.testRetryPlugin)

--- a/uaa/build.gradle
+++ b/uaa/build.gradle
@@ -1,7 +1,6 @@
 Project identityServer = parent.subprojects.find { it.name.equals("cloudfoundry-identity-server") }
 
 apply(plugin: "war")
-apply(plugin: "org.asciidoctor.convert")
 
 processResources {
     //maven replaces project.artifactId in the log4j.properties file


### PR DESCRIPTION
asciidoctor-gradle-plugin [1] is no longer maintained and is causing UAA compilation error:

```
> Could not resolve all artifacts for configuration ':classpath'.
     > Could not find org.ysb33r.gradle:grolifant:0.10.
       Searched in the following locations:
         - https://repo.maven.apache.org/maven2/org/ysb33r/gradle/grolifant/0.10/grolifant-0.10.pom
         - https://plugins.gradle.org/m2/org/ysb33r/gradle/grolifant/0.10/grolifant-0.10.pom
       Required by:
           project : > org.asciidoctor:asciidoctor-gradle-plugin:1.6.1
```

asciidoctor-gradle-plugin is removed from the upstream UAA since version 74.5.x [2]. Remove asciidoctor-gradle-pluginfrom our UAA fork to synchronize with the upstream.

[1] https://asciidoctor.org/docs/asciidoctor-gradle-plugin/
[2] https://github.com/cloudfoundry/uaa/commit/d5cf9f839d20ee5523f593934aff619fa83dc7e9