### PR TITLE
configure single csp uri for all environments

### DIFF
--- a/uaa/src/main/java/org/cloudfoundry/identity/uaa/CSPFilter.java
+++ b/uaa/src/main/java/org/cloudfoundry/identity/uaa/CSPFilter.java
@@ -1,5 +1,8 @@
 package org.cloudfoundry.identity.uaa;
 
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.web.context.ConfigurableWebApplicationContext;
+import org.springframework.core.env.ConfigurableEnvironment;
 import java.io.IOException;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -9,7 +12,18 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletResponse;
 
-public class CSPFilter implements Filter {
+public class CSPFilter implements Filter, ApplicationContextInitializer<ConfigurableWebApplicationContext> {
+
+    private String cspReportUri = "";
+
+    @Override
+    public void initialize(ConfigurableWebApplicationContext applicationContext) {
+        ConfigurableEnvironment env = applicationContext.getEnvironment();
+        String uri = env.getProperty("cspReportUri");
+        if (uri != null && !uri.isEmpty()) {
+            cspReportUri = uri;
+        }
+    }
 
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {
@@ -32,10 +46,9 @@ public class CSPFilter implements Filter {
                         "style-src 'self';" +
                         "object-src 'none';" +
                         "form-action 'self';" +
-                        "report-uri https://tenantporting-prod.run.aws-eu-central-1-pr.ice.predix.io/api/csp-report-uri;"
+                        "report-uri " + cspReportUri + ";"
         );
 
-        // Continue with the next filter in the chain
         chain.doFilter(request, response);
     }
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/CSPFilterTest.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/CSPFilterTest.java
@@ -1,0 +1,111 @@
+package org.cloudfoundry.identity.uaa;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.web.context.ConfigurableWebApplicationContext;
+
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
+
+import static org.mockito.Mockito.*;
+
+public class CSPFilterTest {
+
+    private CSPFilter cspFilter;
+
+    @Mock
+    private ConfigurableWebApplicationContext applicationContext;
+
+    @Mock
+    private ConfigurableEnvironment environment;
+
+    @Mock
+    private FilterConfig filterConfig;
+
+    @Mock
+    private ServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private FilterChain filterChain;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        cspFilter = new CSPFilter();
+        when(applicationContext.getEnvironment()).thenReturn(environment);
+    }
+
+    @Test
+    public void testInitialize_WithValidCspReportUri() {
+        when(environment.getProperty("cspReportUri")).thenReturn("/test-report-uri");
+
+        cspFilter.initialize(applicationContext);
+
+        verify(environment).getProperty("cspReportUri");
+    }
+
+    @Test
+    public void testInitialize_WithEmptyCspReportUri() {
+        when(environment.getProperty("cspReportUri")).thenReturn("");
+
+        cspFilter.initialize(applicationContext);
+
+        verify(environment).getProperty("cspReportUri");
+    }
+
+    @Test
+    public void testInitialize_WithNullCspReportUri() {
+        when(environment.getProperty("cspReportUri")).thenReturn(null);
+
+        cspFilter.initialize(applicationContext);
+
+        verify(environment).getProperty("cspReportUri");
+    }
+
+    @Test
+    public void testDoFilter_SetsCSPHeaders() throws Exception {
+        cspFilter.doFilter(request, response, filterChain);
+
+        verify(response).setHeader("Content-Security-Policy",
+                "base-uri 'self'; frame-ancestors 'none'; font-src 'self' https://cdn.predix-ui.com; img-src 'self'; frame-src 'self';");
+
+        verify(response).setHeader("Content-Security-Policy-Report-Only",
+                "default-src 'self';script-src 'self';style-src 'self';object-src 'none';form-action 'self';report-uri ;");
+
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    public void testDoFilter_WithConfiguredReportUri() throws Exception {
+        when(environment.getProperty("cspReportUri")).thenReturn("/custom-report-uri");
+        cspFilter.initialize(applicationContext);
+
+        cspFilter.doFilter(request, response, filterChain);
+
+        verify(response).setHeader("Content-Security-Policy-Report-Only",
+                "default-src 'self';script-src 'self';style-src 'self';object-src 'none';form-action 'self';report-uri /custom-report-uri;");
+
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    public void testInit_DoesNotThrowException() throws Exception {
+        cspFilter.init(filterConfig);
+        // Test passes if no exception is thrown
+    }
+
+    @Test
+    public void testDestroy_DoesNotThrowException() {
+        cspFilter.destroy();
+        // Test passes if no exception is thrown
+    }
+}


### PR DESCRIPTION
we had csp report-uri as a hardcoded URL. Configured a single url which can be used for all environments like prod and non-prod. It will fetch the env from deployment configure repo and send the csp report accordingly.