### PR TITLE
restrict legacy password grant without secret to whitelisted zones

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/ClientDetailsAuthenticationProvider.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/ClientDetailsAuthenticationProvider.java
@@ -29,9 +29,14 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 
+import org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder;
+
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.cloudfoundry.identity.uaa.oauth.token.TokenConstants.CLIENT_AUTH_EMPTY;
 import static org.cloudfoundry.identity.uaa.oauth.token.TokenConstants.CLIENT_AUTH_NONE;
@@ -41,12 +46,28 @@ import static org.cloudfoundry.identity.uaa.util.UaaStringUtils.getSafeParameter
 public class ClientDetailsAuthenticationProvider extends DaoAuthenticationProvider {
 
     private final JwtClientAuthentication jwtClientAuthentication;
+    private final Set<String> legacyNoSecretAllowedZoneIds;
 
     public ClientDetailsAuthenticationProvider(UserDetailsService userDetailsService, PasswordEncoder encoder, JwtClientAuthentication jwtClientAuthentication) {
+        this(userDetailsService, encoder, jwtClientAuthentication, Collections.emptySet());
+    }
+
+    public ClientDetailsAuthenticationProvider(UserDetailsService userDetailsService, PasswordEncoder encoder, JwtClientAuthentication jwtClientAuthentication, Set<String> legacyNoSecretAllowedZoneIds) {
         super();
         setUserDetailsService(userDetailsService);
         setPasswordEncoder(encoder);
         this.jwtClientAuthentication = jwtClientAuthentication;
+        this.legacyNoSecretAllowedZoneIds = legacyNoSecretAllowedZoneIds != null ? legacyNoSecretAllowedZoneIds : Collections.emptySet();
+    }
+
+    public static Set<String> parseZoneIds(String commaSeparatedZoneIds) {
+        if (commaSeparatedZoneIds == null || commaSeparatedZoneIds.isBlank()) {
+            return Collections.emptySet();
+        }
+        return Arrays.stream(commaSeparatedZoneIds.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.toSet());
     }
 
     @Override
@@ -76,8 +97,8 @@ public class ClientDetailsAuthenticationProvider extends DaoAuthenticationProvid
                             error = new BadCredentialsException("Bad client_assertion type");
                         }
                         break;
-                    } else if (isLegacyNoSecretFlowAllowed(authentication.getDetails())) {
-                        // Allow legacy clients without secrets for password grant type
+                    } else if (isLegacyNoSecretFlowAllowed(authentication.getDetails(), legacyNoSecretAllowedZoneIds)) {
+                        // Allow legacy clients without secrets for password grant type only for whitelisted zone IDs
                         setAuthenticationMethod(authentication, CLIENT_AUTH_EMPTY);
                         break;
                     } else {
@@ -122,11 +143,19 @@ public class ClientDetailsAuthenticationProvider extends DaoAuthenticationProvid
                 && TokenConstants.GRANT_TYPE_PASSWORD.equals(getSafeParameterValue(requestParameters.get(ClaimConstants.GRANT_TYPE)));
     }
 
-    private static boolean isLegacyNoSecretFlowAllowed(Object uaaAuthenticationDetails) {
+    private static boolean isLegacyNoSecretFlowAllowed(Object uaaAuthenticationDetails, Set<String> allowedZoneIds) {
+        if (allowedZoneIds.isEmpty()) {
+            return false;
+        }
+        String currentZoneId = IdentityZoneHolder.getCurrentZoneId();
+        if (!allowedZoneIds.contains(currentZoneId)) {
+            return false;
+        }
         UaaAuthenticationDetails authenticationDetails = getUaaAuthenticationDetails(uaaAuthenticationDetails);
         Map<String, String[]> requestParameters = getRequestParameters(authenticationDetails);
         // Legacy support: only password grant is allowed without client secret
         // Password grant validates user credentials, so client secret is optional for backward compatibility
+        // This is restricted to whitelisted identity zone IDs only
         return isPublicTokenRequest(authenticationDetails) && isPasswordFlow(requestParameters);
     }
 

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/beans/OauthEndpointBeanConfiguration.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/beans/OauthEndpointBeanConfiguration.java
@@ -446,12 +446,14 @@ public class OauthEndpointBeanConfiguration {
     ClientDetailsAuthenticationProvider clientAuthenticationProvider(
             @Qualifier("clientDetailsUserService") UserDetailsService clientDetailsUserService,
             @Qualifier("cachingPasswordEncoder") PasswordEncoder cachingPasswordEncoder,
-            @Qualifier("jwtClientAuthentication") JwtClientAuthentication jwtClientAuthentication
+            @Qualifier("jwtClientAuthentication") JwtClientAuthentication jwtClientAuthentication,
+            @Value("${UAA_LEGACY_NOSECRET_ALLOWED_ZONE_IDS:}") String legacyNoSecretAllowedZoneIds
     ) {
         return new ClientDetailsAuthenticationProvider(
                 clientDetailsUserService,
                 cachingPasswordEncoder,
-                jwtClientAuthentication
+                jwtClientAuthentication,
+                ClientDetailsAuthenticationProvider.parseZoneIds(legacyNoSecretAllowedZoneIds)
         );
     }
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/UaaClientAuthenticationProviderTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/UaaClientAuthenticationProviderTest.java
@@ -30,6 +30,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -278,5 +279,114 @@ class UaaClientAuthenticationProviderTest {
         authenticationProvider.additionalAuthenticationChecks(
                 new UaaClient("client", "secret", Collections.emptyList(), client.getAdditionalInformation(), null), a);
         assertThat(a).isNotNull();
+    }
+
+    // --- Tests for parseZoneIds utility ---
+
+    @Test
+    void parseZoneIds_null_returns_empty() {
+        assertThat(ClientDetailsAuthenticationProvider.parseZoneIds(null)).isEmpty();
+    }
+
+    @Test
+    void parseZoneIds_blank_returns_empty() {
+        assertThat(ClientDetailsAuthenticationProvider.parseZoneIds("  ")).isEmpty();
+    }
+
+    @Test
+    void parseZoneIds_empty_string_returns_empty() {
+        assertThat(ClientDetailsAuthenticationProvider.parseZoneIds("")).isEmpty();
+    }
+
+    @Test
+    void parseZoneIds_single_value() {
+        assertThat(ClientDetailsAuthenticationProvider.parseZoneIds("zone1")).containsExactly("zone1");
+    }
+
+    @Test
+    void parseZoneIds_multiple_values_with_whitespace() {
+        assertThat(ClientDetailsAuthenticationProvider.parseZoneIds("zone1, zone2 , zone3"))
+                .containsExactlyInAnyOrder("zone1", "zone2", "zone3");
+    }
+
+    @Test
+    void parseZoneIds_trailing_comma_ignored() {
+        assertThat(ClientDetailsAuthenticationProvider.parseZoneIds("zone1,zone2,"))
+                .containsExactlyInAnyOrder("zone1", "zone2");
+    }
+
+    // --- Tests for zone-restricted legacy no-secret password grant ---
+
+    @Test
+    void provider_password_grant_without_secret_allowed_for_whitelisted_zone() {
+        // Create provider with current zone whitelisted
+        String currentZoneId = IdentityZoneHolder.getCurrentZoneId();
+        UaaClientDetailsUserDetailsService clientDetailsService = new UaaClientDetailsUserDetailsService(jdbcClientDetailsService);
+        ClientDetailsAuthenticationProvider whitelistedProvider = new ClientDetailsAuthenticationProvider(
+                clientDetailsService, passwordEncoder, jwtClientAuthentication,
+                Set.of(currentZoneId));
+
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/oauth/token");
+        request.addParameter("client_id", "testclient");
+        request.addParameter("grant_type", "password");
+        UsernamePasswordAuthenticationToken a = getAuthenticationToken(request);
+
+        // Client with no password - should be allowed for whitelisted zone
+        UaaClient uaaClient = new UaaClient("client", null, Collections.emptyList(), Collections.emptyMap(), null);
+        whitelistedProvider.additionalAuthenticationChecks(uaaClient, a);
+        assertThat(a).isNotNull();
+    }
+
+    @Test
+    void provider_password_grant_without_secret_rejected_for_non_whitelisted_zone() {
+        // Create provider with a different zone whitelisted (not the current one)
+        UaaClientDetailsUserDetailsService clientDetailsService = new UaaClientDetailsUserDetailsService(jdbcClientDetailsService);
+        ClientDetailsAuthenticationProvider restrictedProvider = new ClientDetailsAuthenticationProvider(
+                clientDetailsService, passwordEncoder, jwtClientAuthentication,
+                Set.of("some-other-zone-id"));
+
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/oauth/token");
+        request.addParameter("client_id", "testclient");
+        request.addParameter("grant_type", "password");
+        UsernamePasswordAuthenticationToken a = getAuthenticationToken(request);
+
+        UaaClient uaaClient = new UaaClient("client", null, Collections.emptyList(), Collections.emptyMap(), null);
+        assertThatThrownBy(() -> restrictedProvider.additionalAuthenticationChecks(uaaClient, a))
+                .isInstanceOf(BadCredentialsException.class)
+                .hasMessage("Missing credentials");
+    }
+
+    @Test
+    void provider_password_grant_without_secret_rejected_when_no_zones_whitelisted() {
+        // Default provider has empty whitelist (no zones allowed)
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/oauth/token");
+        request.addParameter("client_id", "testclient");
+        request.addParameter("grant_type", "password");
+        UsernamePasswordAuthenticationToken a = getAuthenticationToken(request);
+
+        UaaClient uaaClient = new UaaClient("client", null, Collections.emptyList(), Collections.emptyMap(), null);
+        assertThatThrownBy(() -> authenticationProvider.additionalAuthenticationChecks(uaaClient, a))
+                .isInstanceOf(BadCredentialsException.class)
+                .hasMessage("Missing credentials");
+    }
+
+    @Test
+    void provider_client_credentials_without_secret_rejected_even_for_whitelisted_zone() {
+        // Legacy no-secret flow should only work for password grant, not client_credentials
+        String currentZoneId = IdentityZoneHolder.getCurrentZoneId();
+        UaaClientDetailsUserDetailsService clientDetailsService = new UaaClientDetailsUserDetailsService(jdbcClientDetailsService);
+        ClientDetailsAuthenticationProvider whitelistedProvider = new ClientDetailsAuthenticationProvider(
+                clientDetailsService, passwordEncoder, jwtClientAuthentication,
+                Set.of(currentZoneId));
+
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/oauth/token");
+        request.addParameter("client_id", "testclient");
+        request.addParameter("grant_type", "client_credentials");
+        UsernamePasswordAuthenticationToken a = getAuthenticationToken(request);
+
+        UaaClient uaaClient = new UaaClient("client", null, Collections.emptyList(), Collections.emptyMap(), null);
+        assertThatThrownBy(() -> whitelistedProvider.additionalAuthenticationChecks(uaaClient, a))
+                .isInstanceOf(BadCredentialsException.class)
+                .hasMessage("Missing credentials");
     }
 }

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/PasswordGrantIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/PasswordGrantIT.java
@@ -101,7 +101,9 @@ class PasswordGrantIT {
 
         try {
             // Test password grant with client credentials in request body (not in Authorization header)
-            // This is an alternative way to authenticate public clients
+            // Password grant without client secret is only allowed for whitelisted zone IDs
+            // (controlled by UAA_LEGACY_NOSECRET_ALLOWED_ZONE_IDS environment variable).
+            // By default, no zone IDs are whitelisted, so this should be rejected.
             HttpHeaders headers = new HttpHeaders();
             headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
             headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
@@ -112,12 +114,15 @@ class PasswordGrantIT {
             postBody.add("username", testAccounts.getUserName());
             postBody.add("password", testAccounts.getPassword());
 
-            ResponseEntity<Void> responseEntity = restOperations.exchange(baseUrl + "/oauth/token",
-                    HttpMethod.POST,
-                    new HttpEntity<>(postBody, headers),
-                    Void.class);
-
-            assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+            try {
+                restOperations.exchange(baseUrl + "/oauth/token",
+                        HttpMethod.POST,
+                        new HttpEntity<>(postBody, headers),
+                        Void.class);
+                fail("Expected password grant without client secret to be rejected when zone is not whitelisted");
+            } catch (HttpClientErrorException e) {
+                assertThat(e.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+            }
         } finally {
             // Clean up the client
             deleteClient(adminAccessToken, clientId);


### PR DESCRIPTION
- Add zone ID whitelist support to ClientDetailsAuthenticationProvider
- Introduce UAA_LEGACY_NOSECRET_ALLOWED_ZONE_IDS environment variable to control which identity zones can use password grant without a client secret
- Parse comma-separated zone IDs and validate current zone against whitelist
- Maintain backward compatibility via constructor delegation
- Update integration test to expect 401 when zone is not whitelisted
- Add comprehensive unit tests for zone-whitelisting logic in UaaClientAuthenticationProviderTest
- Client credentials grant still requires secret regardless of zone whitelist

This improves security by limiting the legacy no-secret password grant flow to explicitly configured identity zones only.