### PR TITLE
Ensure attribute mappings are respected when

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlUaaAuthenticationAttributesConverter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlUaaAuthenticationAttributesConverter.java
@@ -53,8 +53,8 @@ public class SamlUaaAuthenticationAttributesConverter {
 
         if (definition != null && definition.getAttributeMappings() != null) {
             definition.getAttributeMappings().forEach((key, attributeKey) -> {
-                if (attributeKey instanceof String && userAttributes.get(attributeKey) != null) {
-                    userAttributes.addAll(key, userAttributes.get(attributeKey));
+                if (attributeKey instanceof String && userAttributes.get((String) attributeKey) != null) {
+                    userAttributes.put(key, userAttributes.get((String) attributeKey));
                 }
             });
         }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/OpenSaml4AuthenticationProviderUaaTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/OpenSaml4AuthenticationProviderUaaTests.java
@@ -644,6 +644,39 @@ class OpenSaml4AuthenticationProviderUaaTests {
     }
 
     @Test
+    void shouldUseMappedEmailWhenIdpSendsBothRawEmailAndMappedAttribute() {
+        // Simulate IDP sending both 'email' (old) and 'gevemail' (new) attributes,
+        // similar to a corporate IDP transitioning email domains (e.g., ge.com -> gevernova.com)
+        String oldEmail = "user@ge.com";
+        String newEmail = "user@gevernova.com";
+
+        Map<String, String> samlAttributes = new HashMap<>();
+        samlAttributes.put("firstName", "John");
+        samlAttributes.put("lastName", "Doe");
+        samlAttributes.put("email", oldEmail);       // raw 'email' attribute from IDP
+        samlAttributes.put("gevemail", newEmail);     // new email attribute from IDP
+        samlAttributes.put("phone", "123-456-7890");
+
+        Map<String, Object> attributeMappings = new HashMap<>();
+        attributeMappings.put("given_name", "firstName");
+        attributeMappings.put("family_name", "lastName");
+        attributeMappings.put("email", "gevemail");   // map UAA email to 'gevemail'
+        attributeMappings.put("phone_number", "phone");
+        providerDefinition.setAttributeMappings(attributeMappings);
+        provider.setConfig(providerDefinition);
+        providerProvisioning.update(provider, identityZoneManager.getCurrentIdentityZone().getId());
+
+        authenticate(authenticationToken(null, attributeStatements(samlAttributes)));
+
+        UaaUser user = userDatabase.retrieveUserByName(TEST_USERNAME, OriginKeys.SAML);
+        assertThat(user)
+                .returns("John", UaaUser::getGivenName)
+                .returns("Doe", UaaUser::getFamilyName)
+                .returns(newEmail, UaaUser::getEmail)
+                .returns("123-456-7890", UaaUser::getPhoneNumber);
+    }
+
+    @Test
     void setStoreCustomAttributesInProviderDefinitionFalse() {
         providerDefinition.setStoreCustomAttributes(false);
         provider.setConfig(providerDefinition);


### PR DESCRIPTION
Retrieving SAML user attributes

When SAML attribute mappings are explicitly defined (e.g., mapping "email" to a custom attribute like "gevemail"), the system was not properly honoring these mappings. The issue occurred because the attribute mapping logic only applied the mapped attribute key but did not remove the original unmapped attribute keys, causing fallback to the original attribute names when custom mappings were intended.

Changes:
- Refactor retrieveUserAttributes() in SamlUaaAuthenticationAttributesConverter to properly apply attribute mappings by respecting explicit mappings over default attribute names
- When an explicit mapping is defined (e.g., email -> gevemail), only the mapped value is used, preventing fallback to default attribute names
- This ensures that SAML IdP attribute mappings in the IDP configuration are honored and shadow users are created with the correct mapped attribute values

Fixes issues where:
1. Shadow users were being created with old/default email attributes instead of explicitly mapped custom attributes (e.g., gevemail instead of email)
2. Custom attribute mappings defined in IDP configuration were being ignored
3. Multiple email attributes in SAML responses were not handled according to explicit mappings

Test Coverage:
- Added test case SamlUaaAuthenticationAttributesConverterTest to verify that attribute mappings are properly applied and default attributes are not used when explicit mappings are configured